### PR TITLE
Fix :stories

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -428,8 +428,10 @@ class Instaloader:
 
         if not userids:
             self.context.log("Retrieving all visible stories...")
+        else:
+            userids = [p if isinstance(p, int) else p.userid for p in userids]
 
-        for user_story in self.get_stories([p if isinstance(p, int) else p.userid for p in userids]):
+        for user_story in self.get_stories(userids):
             name = user_story.owner_username
             self.context.log("Retrieving stories from profile {}.".format(name))
             totalcount = user_story.itemcount


### PR DESCRIPTION
50a5330fecb1272487fdd600416354c83ef8922f breaks `:stories` since userids is None (non-iterable).
Maybe `get_stories()` should also be adjusted to accept the empty list as `userids`, not only `None`, as an indication that all stories are to be retrieved.

And maybe https://github.com/instaloader/instaloader/blob/7f81985911721115566e5516bb34e7b2c80c2165/instaloader/__main__.py#L121-L126
ought to, at least, emit a warning if `stories_only`. I suppose there might be a semi-valid usecase for `--stories-only @user1 @user2 ...`. But `if stories_only and target[1:] == username` I don't see any reason to bother fetching the followees at all.
Similarly, people using `@myself --fast-update` could be steered towards `:feed`, possibly with an apropriate path pattern. Since that would accomplish what they're probably aiming for (plus some free comments), in fewer GQL calls (right?).