### PR TITLE
There can be comments without any answers

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -276,7 +276,7 @@ class Instaloader:
         comments.extend(_postcomment_asdict(comment) for comment in post.get_comments())
         if comments:
             comments = get_unique_comments(comments, combine_answers=True)
-            answer_ids = set(int(answer['id']) for comment in comments for answer in comment.get('answers'))
+            answer_ids = set(int(answer['id']) for comment in comments for answer in comment.get('answers', []))
             with open(filename, 'w') as file:
                 file.write(json.dumps(list(filter(lambda t: int(t['id']) not in answer_ids, comments)), indent=4))
             self.context.log('comments', end=' ', flush=True)


### PR DESCRIPTION
```
Retrieving posts from profile xxx.
[  1/ 19] 1920293015977865613 - 2018-11-09_01-17-30.jpg exists ["real …] unchanged Traceback (most recent call last):
  File "/usr/bin/instaloader", line 11, in <module>
    load_entry_point('instaloader==4.2.4', 'console_scripts', 'instaloader')()
  File "/usr/lib/python3.7/site-packages/instaloader/__main__.py", line 410, in main
    storyitem_filter_str=args.storyitem_filter)
  File "/usr/lib/python3.7/site-packages/instaloader/__main__.py", line 186, in _main
    download_stories, fast_update, post_filter, storyitem_filter)
  File "/usr/lib/python3.7/site-packages/instaloader/instaloader.py", line 999, in download_profiles
    downloaded = self.download_post(post, target=profile_name)
  File "/usr/lib/python3.7/site-packages/instaloader/instaloader.py", line 480, in download_post
    self.update_comments(filename=filename, post=post)
  File "/usr/lib/python3.7/site-packages/instaloader/instaloader.py", line 279, in update_comments
    answer_ids = set(int(answer['id']) for comment in comments for answer in comment.get('answers'))
  File "/usr/lib/python3.7/site-packages/instaloader/instaloader.py", line 279, in <genexpr>
    answer_ids = set(int(answer['id']) for comment in comments for answer in comment.get('answers'))
TypeError: 'NoneType' object is not iterable
```
