### PR TITLE
Special character edit

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -650,7 +650,7 @@ class Instaloader:
                                                                                                  name)):
                     downloaded = self.download_storyitem(item, filename_target
                                                          if filename_target
-                                                         else Path(name) / Path(user_highlight.title + ' '))
+                                                         else Path(name) / Path(user_highlight.title + 'ㅤㅤ ㅤㅤ'))
                     if fast_update and not downloaded:
                         break
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -650,7 +650,7 @@ class Instaloader:
                                                                                                  name)):
                     downloaded = self.download_storyitem(item, filename_target
                                                          if filename_target
-                                                         else Path(name) / Path(user_highlight.title))
+                                                         else Path(name) / Path(user_highlight.title + ' '))
                     if fast_update and not downloaded:
                         break
 


### PR DESCRIPTION
Add empty space in the end of the directory of the highlights because some users use some special characters that windows dont permit.