### PR TITLE
Use 'edge_media_to_comment' instead of 'edge_media_to_parent_comment' in Post

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -326,9 +326,9 @@ class Post:
     def comments(self) -> int:
         """Comment count including answers"""
         try:
-            return self._field('edge_media_to_parent_comment', 'count')
-        except KeyError:
             return self._field('edge_media_to_comment', 'count')
+        except KeyError:
+            return self._field('edge_media_to_parent_comment', 'count')
 
     def get_comments(self) -> Iterator[PostComment]:
         r"""Iterate over all comments of the post.


### PR DESCRIPTION
This change make Instaloader use 'edge_media_to_comment' instead of 'edge_media_to_parent_comment' to speed up crawling the number of comments for posts (Post).