### PR TITLE
Workaround for Instagram's encrypted login.

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -7,7 +7,6 @@ import shutil
 import sys
 import textwrap
 import time
-import calendar
 import urllib.parse
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -216,9 +215,11 @@ class InstaloaderContext:
         session.headers.update({'X-CSRFToken': csrf_token})
         # Not using self.get_json() here, because we need to access csrftoken cookie
         self.do_sleep()
-        # Workaround credits to pgrimaud. See: https://github.com/pgrimaud/instagram-user-feed/commit/96ad4cf54d1ad331b337f325c73e664999a6d066
+        # Workaround credits to pgrimaud.
+        # See: https://github.com/pgrimaud/instagram-user-feed/commit/96ad4cf54d1ad331b337f325c73e664999a6d066
+        enc_password = '#PWD_INSTAGRAM_BROWSER:0:{}:{}'.format(int(datetime.now().timestamp()), passwd)
         login = session.post('https://www.instagram.com/accounts/login/ajax/',
-                             data={'enc_password': f'#PWD_INSTAGRAM_BROWSER:0:{calendar.timegm(time.gmtime())}:{passwd}', 'username': user}, allow_redirects=True)
+                             data={'enc_password': enc_password, 'username': user}, allow_redirects=True)
         try:
             resp_json = login.json()
         except json.decoder.JSONDecodeError:

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import textwrap
 import time
+import calendar
 import urllib.parse
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -215,8 +216,9 @@ class InstaloaderContext:
         session.headers.update({'X-CSRFToken': csrf_token})
         # Not using self.get_json() here, because we need to access csrftoken cookie
         self.do_sleep()
+        # Workaround credits to pgrimaud. See: https://github.com/pgrimaud/instagram-user-feed/commit/96ad4cf54d1ad331b337f325c73e664999a6d066
         login = session.post('https://www.instagram.com/accounts/login/ajax/',
-                             data={'password': passwd, 'username': user}, allow_redirects=True)
+                             data={'enc_password': f'#PWD_INSTAGRAM_BROWSER:0:{calendar.timegm(time.gmtime())}:{passwd}', 'username': user}, allow_redirects=True)
         try:
             resp_json = login.json()
         except json.decoder.JSONDecodeError:


### PR DESCRIPTION
Upon checking the POST request made by Instagram, they started encrypting the password starting with `#PWD_INSTAGRAM_BROWSER:10`, in my case. When looking at the source, I came across the following:

```js
const t = '#PWD_INSTAGRAM_BROWSER',
    n = Object.freeze({
    PLAINTEXT: '0',
    ROTATED_ENCRYPT: '6',
    FALLBACK_ENCRYPT: '9'
});
```

Apparently the new request sends it in the form of something like `<#endpoint>:<encryption_version>:<timestamp>:<aes(?)_encrypted_password>`. However, as @pgrimaud found, we can send the login request using the plaintext password as opposed to having to encrypt it.

Of course this is only a temporary solution. I think it'd be better to implement the encryption; however, this will do in the meantime.

Solves: https://github.com/instaloader/instaloader/issues/615
**Workaround Credit**: @pgrimaud
**See**: https://github.com/pgrimaud/instagram-user-feed/commit/96ad4cf54d1ad331b337f325c73e664999a6d066

---

Further resources:
https://github.com/dilame/instagram-private-api/issues/1010
https://github.com/FeezyHendrix/Insta-mass-account-creator/issues/140