### PR TITLE
Fix _obtain_metadata in Profile class

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -569,8 +569,8 @@ class Profile:
     def _obtain_metadata(self):
         try:
             if not self._has_full_metadata:
-                metadata = self._context.get_json('{}/'.format(self.username), params={})
-                self._node = metadata['entry_data']['ProfilePage'][0]['graphql']['user']
+                metadata = self._context.get_json('{}/'.format(self.username), params={'__a': 1})
+           	self._node = metadata['graphql']['user']
                 self._has_full_metadata = True
                 self._rhx_gis = metadata.get('rhx_gis')
         except (QueryReturnedNotFoundException, KeyError) as err:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -570,7 +570,7 @@ class Profile:
         try:
             if not self._has_full_metadata:
                 metadata = self._context.get_json('{}/'.format(self.username), params={'__a': 1})
-           	self._node = metadata['graphql']['user']
+                self._node = metadata['graphql']['user']
                 self._has_full_metadata = True
                 self._rhx_gis = metadata.get('rhx_gis')
         except (QueryReturnedNotFoundException, KeyError) as err:


### PR DESCRIPTION
Fixes errors in instaloader.Profile.from_username,  instaloader.Instaloader().check_profile_id where ProfileNotFoundException is raised by KeyError on graphql 