### PR TITLE
More flexible Rate Controller

### DIFF
--- a/docs/as-module.rst
+++ b/docs/as-module.rst
@@ -229,5 +229,16 @@ Exceptions
 ``InstaloaderContext`` (Low-level functions)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+``InstaloaderContext``
+""""""""""""""""""""""
+
 .. autoclass:: InstaloaderContext
    :no-show-inheritance:
+
+``RateController``
+""""""""""""""""""
+
+.. autoclass:: RateController
+   :no-show-inheritance:
+
+   .. versionadded:: 4.5

--- a/instaloader/__init__.py
+++ b/instaloader/__init__.py
@@ -14,6 +14,6 @@ else:
 
 from .exceptions import *
 from .instaloader import Instaloader
-from .instaloadercontext import InstaloaderContext
+from .instaloadercontext import InstaloaderContext, RateController
 from .structures import (Hashtag, Highlight, Post, PostSidecarNode, PostComment, PostCommentAnswer, PostLocation,
                          Profile, Story, StoryItem, TopSearchResults, load_structure_from_file, save_structure_to_file)

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -19,7 +19,7 @@ import requests
 import urllib3  # type: ignore
 
 from .exceptions import *
-from .instaloadercontext import InstaloaderContext
+from .instaloadercontext import InstaloaderContext, RateController
 from .structures import (Hashtag, Highlight, JsonExportable, Post, PostLocation, Profile, Story, StoryItem,
                          save_structure_to_file)
 
@@ -153,6 +153,7 @@ class Instaloader:
     :param storyitem_metadata_txt_pattern: :option:`--storyitem-metadata-txt`, default is empty (=none)
     :param max_connection_attempts: :option:`--max-connection-attempts`
     :param request_timeout: :option:`--request-timeout`, set per-request timeout (seconds)
+    :param rate_controller: Generator for a :class:`RateController` to override rate controlling behavior
 
     .. attribute:: context
 
@@ -175,9 +176,11 @@ class Instaloader:
                  post_metadata_txt_pattern: str = None,
                  storyitem_metadata_txt_pattern: str = None,
                  max_connection_attempts: int = 3,
-                 request_timeout: Optional[float] = None):
+                 request_timeout: Optional[float] = None,
+                 rate_controller: Optional[Callable[[InstaloaderContext], RateController]] = None):
 
-        self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts, request_timeout)
+        self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
+                                          request_timeout, rate_controller)
 
         # configuration parameters
         self.dirname_pattern = dirname_pattern or "{target}"


### PR DESCRIPTION
Move InstaloaderContext's rate controlling logic into a class RateController with fine-grained methods to enable easily changing Instaloader's behavior regarding rate limits.

For example, this makes it possible to easily
- raise an exception instead of sleeping, as has been asked for in #641, by overriding `RateController.sleep()`,
- use a lower query rate than default, by overriding `RateController.count_per_sliding_window()`.

Also, this changes the rate for logged-in queries as it seems that higher rates are allowed now.