### PR TITLE
Resume a previously-aborted post download loop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,9 @@
   directory accordingly,
 
 - allows **fine-grained customization** of filters and where to store
-  downloaded media.
+  downloaded media,
+
+- automatically **resumes previously-interrupted** download iterations.
 
 ::
 

--- a/docs/as-module.rst
+++ b/docs/as-module.rst
@@ -226,8 +226,8 @@ Exceptions
 
 .. autoexception:: TooManyRequestsException
 
-``NodeIterator`` (Interruptable Iterator)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Resumable Iterations
+^^^^^^^^^^^^^^^^^^^^
 
 .. versionadded:: 4.5
 
@@ -236,6 +236,8 @@ Exceptions
 
 .. autoclass:: FrozenNodeIterator
    :no-show-inheritance:
+
+.. autofunction:: resumable_iteration
 
 ``InstaloaderContext`` (Low-level functions)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/as-module.rst
+++ b/docs/as-module.rst
@@ -226,6 +226,17 @@ Exceptions
 
 .. autoexception:: TooManyRequestsException
 
+``NodeIterator`` (Interruptable Iterator)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 4.5
+
+.. autoclass:: NodeIterator
+   :no-show-inheritance:
+
+.. autoclass:: FrozenNodeIterator
+   :no-show-inheritance:
+
 ``InstaloaderContext`` (Low-level functions)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -239,19 +250,6 @@ Exceptions
 """"""""""""""""""
 
 .. autoclass:: RateController
-   :no-show-inheritance:
-
-   .. versionadded:: 4.5
-
-``NodeIterator``
-""""""""""""""""
-
-.. autoclass:: NodeIterator
-   :no-show-inheritance:
-
-   .. versionadded:: 4.5
-
-.. autoclass:: FrozenNodeIterator
    :no-show-inheritance:
 
    .. versionadded:: 4.5

--- a/docs/as-module.rst
+++ b/docs/as-module.rst
@@ -242,3 +242,16 @@ Exceptions
    :no-show-inheritance:
 
    .. versionadded:: 4.5
+
+``NodeIterator``
+""""""""""""""""
+
+.. autoclass:: NodeIterator
+   :no-show-inheritance:
+
+   .. versionadded:: 4.5
+
+.. autoclass:: FrozenNodeIterator
+   :no-show-inheritance:
+
+   .. versionadded:: 4.5

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -223,6 +223,25 @@ How to Download
    ``#hashtag`` or the profile name. Defaults to ``{date_utc}_UTC``.
    See :ref:`filename-specification` for a list of supported tokens.
 
+.. option:: --resume-prefix prefix
+
+   For many targets, Instaloader is capable of resuming a previously-aborted
+   download loop.  To do so, it creates a JSON file within the target directory
+   when interrupted.  This option controls the prefix for filenames that are
+   used to save the information to resume an interrupted download.  The default
+   prefix is ``iterator``.
+
+   Resuming an interrupted download is supported for most, but not all targets.
+   JSON files with resume information are always compressed, regardless of
+   :option:`--no-compress-json`.
+
+   This feature is turned off entirely with :option:`--no-resume`.
+
+.. option:: --no-resume
+
+   Do not resume a previously-aborted download iteration, and do not save such
+   information when interrupted.
+
 .. option:: --user-agent USER_AGENT
 
    User Agent to use for HTTP requests. Per default, Instaloader pretends being

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -237,10 +237,14 @@ How to Download
 
    This feature is turned off entirely with :option:`--no-resume`.
 
+   .. versionadded:: 4.5
+
 .. option:: --no-resume
 
    Do not resume a previously-aborted download iteration, and do not save such
    information when interrupted.
+
+   .. versionadded:: 4.5
 
 .. option:: --user-agent USER_AGENT
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,8 @@ autodoc_member_order = 'bysource'
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'requests': ('https://requests.kennethreitz.org/en/master/', None)}
 
+nitpick_ignore = [('py:class', 'typing.Tuple')]
+
 current_release = subprocess.check_output(["git", "describe", "--abbrev=0"]).decode("ascii")[1:-1]
 date_format = "%e %b %Y" if platform.system() != "Windows" else "%d %b %Y"
 current_release_date = subprocess.check_output(

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,8 @@ See :ref:`install` for more options on how to install Instaloader.
 - allows **fine-grained customization** of filters and where to store
   downloaded media,
 
+- automatically **resumes previously-interrupted** download iterations,
+
 - is free `open source <https://github.com/instaloader/instaloader>`__
   software written in Python.
 

--- a/instaloader/__init__.py
+++ b/instaloader/__init__.py
@@ -15,5 +15,6 @@ else:
 from .exceptions import *
 from .instaloader import Instaloader
 from .instaloadercontext import InstaloaderContext, RateController
+from .nodeiterator import NodeIterator, FrozenNodeIterator
 from .structures import (Hashtag, Highlight, Post, PostSidecarNode, PostComment, PostCommentAnswer, PostLocation,
                          Profile, Story, StoryItem, TopSearchResults, load_structure_from_file, save_structure_to_file)

--- a/instaloader/__init__.py
+++ b/instaloader/__init__.py
@@ -15,6 +15,6 @@ else:
 from .exceptions import *
 from .instaloader import Instaloader
 from .instaloadercontext import InstaloaderContext, RateController
-from .nodeiterator import NodeIterator, FrozenNodeIterator
+from .nodeiterator import NodeIterator, FrozenNodeIterator, resumable_iteration
 from .structures import (Hashtag, Highlight, Post, PostSidecarNode, PostComment, PostCommentAnswer, PostLocation,
                          Profile, Story, StoryItem, TopSearchResults, load_structure_from_file, save_structure_to_file)

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -351,6 +351,12 @@ def main():
                             '--dirname-pattern. {profile} is replaced by the profile name,'
                             '{target} is replaced by the target you specified, i.e. either :feed'
                             '#hashtag or the profile name. Defaults to \'{date_utc}_UTC\'')
+    g_how.add_argument('--resume-prefix', metavar='PREFIX',
+                       help='Prefix for filenames that are used to save the information to resume an interrupted '
+                            'download.')
+    g_how.add_argument('--no-resume', action='store_true',
+                       help='Do not resume a previously-aborted download iteration, and do not store save information '
+                            'when interrupted.')
     g_how.add_argument('--user-agent',
                        help='User Agent to use for HTTP requests. Defaults to \'{}\'.'.format(default_user_agent()))
     g_how.add_argument('-S', '--no-sleep', action='store_true', help=SUPPRESS)
@@ -394,6 +400,10 @@ def main():
                 raise SystemExit("--no-captions and --post-metadata-txt or --storyitem-metadata-txt given; "
                                  "That contradicts.")
 
+        if args.no_resume and args.resume_prefix:
+            raise SystemExit("--no-resume and --resume-prefix given; That contradicts.")
+        resume_prefix = (args.resume_prefix if args.resume_prefix else 'iterator') if not args.no_resume else None
+
         if args.no_pictures and args.fast_update:
             raise SystemExit('--no-pictures and --fast-update cannot be used together.')
 
@@ -412,7 +422,8 @@ def main():
                              post_metadata_txt_pattern=post_metadata_txt_pattern,
                              storyitem_metadata_txt_pattern=storyitem_metadata_txt_pattern,
                              max_connection_attempts=args.max_connection_attempts,
-                             request_timeout=args.request_timeout)
+                             request_timeout=args.request_timeout,
+                             resume_prefix=resume_prefix)
         _main(loader,
               args.profile,
               username=args.login.lower() if args.login is not None else None,

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -425,7 +425,7 @@ def main():
                              max_connection_attempts=args.max_connection_attempts,
                              request_timeout=args.request_timeout,
                              resume_prefix=resume_prefix,
-                             check_resume_doe=not args.use_aged_resume_files)
+                             check_resume_bbd=not args.use_aged_resume_files)
         _main(loader,
               args.profile,
               username=args.login.lower() if args.login is not None else None,

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -355,7 +355,7 @@ def main():
                        help='Prefix for filenames that are used to save the information to resume an interrupted '
                             'download.')
     g_how.add_argument('--no-resume', action='store_true',
-                       help='Do not resume a previously-aborted download iteration, and do not store save information '
+                       help='Do not resume a previously-aborted download iteration, and do not save such information '
                             'when interrupted.')
     g_how.add_argument('--user-agent',
                        help='User Agent to use for HTTP requests. Defaults to \'{}\'.'.format(default_user_agent()))

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -357,6 +357,7 @@ def main():
     g_how.add_argument('--no-resume', action='store_true',
                        help='Do not resume a previously-aborted download iteration, and do not save such information '
                             'when interrupted.')
+    g_how.add_argument('--use-aged-resume-files', action='store_true', help=SUPPRESS)
     g_how.add_argument('--user-agent',
                        help='User Agent to use for HTTP requests. Defaults to \'{}\'.'.format(default_user_agent()))
     g_how.add_argument('-S', '--no-sleep', action='store_true', help=SUPPRESS)
@@ -423,7 +424,8 @@ def main():
                              storyitem_metadata_txt_pattern=storyitem_metadata_txt_pattern,
                              max_connection_attempts=args.max_connection_attempts,
                              request_timeout=args.request_timeout,
-                             resume_prefix=resume_prefix)
+                             resume_prefix=resume_prefix,
+                             check_resume_doe=not args.use_aged_resume_files)
         _main(loader,
               args.profile,
               username=args.login.lower() if args.login is not None else None,

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -799,6 +799,7 @@ class Instaloader:
             if self.resume_prefix is not None:
                 if resume_file_path is not None:
                     assert isinstance(posts, NodeIterator)
+                    os.makedirs(os.path.dirname(resume_file_path), exist_ok=True)
                     save_structure_to_file(posts.freeze(), resume_file_path)
                     self.context.log("\nSaved resume information for {} to {}.".format(target, resume_file_path))
                 else:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1,5 +1,6 @@
 import getpass
 import json
+import lzma
 import os
 import platform
 import re
@@ -751,7 +752,7 @@ class Instaloader:
                 resume_offset = posts.total_index
                 is_resuming = True
                 self.context.log("Resuming download from {}.".format(resume_file_path))
-            except InvalidArgumentException as exc:
+            except (InvalidArgumentException, lzma.LZMAError, json.decoder.JSONDecodeError) as exc:
                 self.context.error("Warning: Resuming download from {} failed: {}".format(resume_file_path, exc))
             except FileNotFoundError:
                 pass

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -156,7 +156,7 @@ class Instaloader:
     :param request_timeout: :option:`--request-timeout`, set per-request timeout (seconds)
     :param rate_controller: Generator for a :class:`RateController` to override rate controlling behavior
     :param resume_prefix: :option:`--resume-prefix`, or None for :option:`--no-resume`.
-    :param check_resume_doe: Whether to check the date of expiry of resume files and reject them if expired.
+    :param check_resume_bbd: Whether to check the date of expiry of resume files and reject them if expired.
 
     .. attribute:: context
 
@@ -182,7 +182,7 @@ class Instaloader:
                  request_timeout: Optional[float] = None,
                  rate_controller: Optional[Callable[[InstaloaderContext], RateController]] = None,
                  resume_prefix: Optional[str] = "iterator",
-                 check_resume_doe: bool = True):
+                 check_resume_bbd: bool = True):
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
                                           request_timeout, rate_controller)
@@ -202,7 +202,7 @@ class Instaloader:
         self.storyitem_metadata_txt_pattern = '' if storyitem_metadata_txt_pattern is None \
             else storyitem_metadata_txt_pattern
         self.resume_prefix = resume_prefix
-        self.check_resume_doe = check_resume_doe
+        self.check_resume_bbd = check_resume_bbd
 
     @contextmanager
     def anonymous_copy(self):
@@ -225,7 +225,7 @@ class Instaloader:
             max_connection_attempts=self.context.max_connection_attempts,
             request_timeout=self.context.request_timeout,
             resume_prefix=self.resume_prefix,
-            check_resume_doe=self.check_resume_doe)
+            check_resume_bbd=self.check_resume_bbd)
         yield new_loader
         self.context.error_log.extend(new_loader.context.error_log)
         new_loader.context.error_log = []  # avoid double-printing of errors
@@ -751,7 +751,7 @@ class Instaloader:
                 format_path=lambda magic: self.format_filename_within_target_path(
                     target, owner_profile, self.resume_prefix or '', magic, 'json.xz'
                 ),
-                check_doe=self.check_resume_doe,
+                check_bbd=self.check_resume_bbd,
                 enabled=self.resume_prefix is not None
         ) as resume_info:
             is_resuming, start_index = resume_info

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -367,7 +367,9 @@ class Instaloader:
                                            identifier: str,
                                            name_suffix: str,
                                            extension: str):
-        """Returns a filename within the target path."""
+        """Returns a filename within the target path.
+
+        .. versionadded:: 4.5"""
         if ((format_string_contains_key(self.dirname_pattern, 'profile') or
              format_string_contains_key(self.dirname_pattern, 'target'))):
             profile_str = owner_profile.username.lower() if owner_profile is not None else target

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -428,7 +428,12 @@ class InstaloaderContext:
                           edge_extractor: Callable[[Dict[str, Any]], Dict[str, Any]],
                           rhx_gis: Optional[str] = None,
                           first_data: Optional[Dict[str, Any]] = None) -> Iterator[Dict[str, Any]]:
-        """Retrieve a list of GraphQL nodes."""
+        """
+        Retrieve a list of GraphQL nodes.
+
+        ..deprecated:: 4.5
+           Use :class:`NodeIterator` instead, which provides more functionality.
+        """
 
         def _query():
             query_variables['first'] = self._graphql_page_length

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -111,7 +111,9 @@ class NodeIterator(Iterator[T]):
         if 'blake2b' not in hashlib.algorithms_available:
             magic_hash = hashlib.new('sha224')
         else:
-            magic_hash = hashlib.blake2b(digest_size=6)
+            # Use blake2b when possible, i.e. on Python >= 3.6.
+            # pylint:disable=no-member
+            magic_hash = hashlib.blake2b(digest_size=6)  # type:ignore
         magic_hash.update(json.dumps(
             [self._query_hash, self._query_variables, self._query_referer, self._context.username]
         ).encode())

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -11,9 +11,12 @@ from .exceptions import InvalidArgumentException, QueryReturnedBadRequestExcepti
 from .instaloadercontext import InstaloaderContext
 
 FrozenNodeIterator = NamedTuple('FrozenNodeIterator',
-                                [('query_hash', str), ('query_variables', Dict), ('query_referer', Optional[str]),
-                                 ('context_username', Optional[str]), ('total_index', int),
-                                 ('best_before_date', Optional[float]),
+                                [('query_hash', str),
+                                 ('query_variables', Dict),
+                                 ('query_referer', Optional[str]),
+                                 ('context_username', Optional[str]),
+                                 ('total_index', int),
+                                 ('best_before', Optional[float]),
                                  ('remaining_data', Optional[Dict])])
 FrozenNodeIterator.__doc__ = \
     """A serializable representation of a :class:`NodeIterator` instance, saving its iteration state."""
@@ -22,7 +25,7 @@ FrozenNodeIterator.query_variables.__doc__ = """The GraphQL ``query_variables`` 
 FrozenNodeIterator.query_referer.__doc__ = """The HTTP referer used for the GraphQL query."""
 FrozenNodeIterator.context_username.__doc__ = """The username who created the iterator, or ``None``."""
 FrozenNodeIterator.total_index.__doc__ = """Number of items that have already been returned."""
-FrozenNodeIterator.best_before_date.__doc__ = """Date when parts of the stored nodes might have expired."""
+FrozenNodeIterator.best_before.__doc__ = """Date when parts of the stored nodes might have expired."""
 FrozenNodeIterator.remaining_data.__doc__ = \
     """The already-retrieved, yet-unprocessed ``edges`` and the ``page_info`` at time of freezing."""
 
@@ -62,7 +65,7 @@ class NodeIterator(Iterator[T]):
     """
 
     _graphql_page_length = 50
-    expiration_time = timedelta(days=29, hours=23)
+    shelf_life = timedelta(days=29)
 
     def __init__(self,
                  context: InstaloaderContext,
@@ -81,8 +84,8 @@ class NodeIterator(Iterator[T]):
         self._data = first_data
         self._page_index = 0
         self._total_index = 0
-        self._best_before_date = (None if first_data is None else
-                                  datetime.now() + NodeIterator.expiration_time)
+        self._best_before = (None if first_data is None else
+                             datetime.now() + NodeIterator.shelf_life)
 
     def _query(self, after: Optional[str] = None) -> Dict:
         pagination_variables = {'first': NodeIterator._graphql_page_length}  # type: Dict[str, Any]
@@ -94,7 +97,7 @@ class NodeIterator(Iterator[T]):
                     self._query_hash, {**self._query_variables, **pagination_variables}, self._query_referer
                 )
             )
-            self._best_before_date = datetime.now() + NodeIterator.expiration_time
+            self._best_before = datetime.now() + NodeIterator.shelf_life
             return data
         except QueryReturnedBadRequestException:
             new_page_length = int(NodeIterator._graphql_page_length / 2)
@@ -169,7 +172,7 @@ class NodeIterator(Iterator[T]):
             query_referer=self._query_referer,
             context_username=self._context.username,
             total_index=max(self.total_index - 1, 0),
-            best_before_date=self._best_before_date.timestamp() if self._best_before_date else None,
+            best_before=self._best_before.timestamp() if self._best_before else None,
             remaining_data=remaining_data,
         )
 
@@ -183,7 +186,7 @@ class NodeIterator(Iterator[T]):
                 self._context.username != frozen.context_username):
             raise InvalidArgumentException("Mismatching resume information.")
         self._total_index = frozen.total_index
-        self._best_before_date = datetime.fromtimestamp(frozen.best_before_date) if frozen.best_before_date else None
+        self._best_before = datetime.fromtimestamp(frozen.best_before) if frozen.best_before else None
         self._data = frozen.remaining_data
 
 
@@ -193,7 +196,7 @@ def resumable_iteration(context: InstaloaderContext,
                         load: Callable[[InstaloaderContext, str], Any],
                         save: Callable[[FrozenNodeIterator, str], None],
                         format_path: Callable[[str], str],
-                        check_doe: bool = True,
+                        check_bbd: bool = True,
                         enabled: bool = True) -> Iterator[Tuple[bool, int]]:
     """
     High-level context manager to handle a resumable iteration that can be interrupted with a KeyboardInterrupt.
@@ -222,7 +225,7 @@ def resumable_iteration(context: InstaloaderContext,
     :param load: Loads a FrozenNodeIterator from given path. A typecheck is done before the returned object is used.
     :param save: Saves the given FrozenNodeIterator to the given path.
     :param format_path: Returns the path to the resume file for the given magic.
-    :param check_doe: Whether to check the date of expiry and reject an expired FrozenNodeIterator.
+    :param check_bbd: Whether to check the best before date and reject an expired FrozenNodeIterator.
     :param enabled: Set to False to disable all functionality and simply execute the inner body.
     """
     if not enabled or not isinstance(iterator, NodeIterator):
@@ -237,8 +240,8 @@ def resumable_iteration(context: InstaloaderContext,
             fni = load(context, resume_file_path)
             if not isinstance(fni, FrozenNodeIterator):
                 raise InvalidArgumentException("Invalid type.")
-            if check_doe and fni.best_before_date and datetime.fromtimestamp(fni.best_before_date) < datetime.now():
-                raise InvalidArgumentException("File too old.")
+            if check_bbd and fni.best_before and datetime.fromtimestamp(fni.best_before) < datetime.now():
+                raise InvalidArgumentException("\"Best before\" date exceeded.")
             iterator.thaw(fni)
             is_resuming = True
             start_index = iterator.total_index

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -112,7 +112,7 @@ class NodeIterator(Iterator[T]):
             magic_hash = hashlib.new('sha224')
         else:
             # Use blake2b when possible, i.e. on Python >= 3.6.
-            magic_hash = hashlib.blake2b(digest_size=6)  # pylint: disable=no-member; type:ignore
+            magic_hash = hashlib.blake2b(digest_size=6)  # type:ignore  # pylint: disable=no-member
         magic_hash.update(json.dumps(
             [self._query_hash, self._query_variables, self._query_referer, self._context.username]
         ).encode())

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -112,8 +112,7 @@ class NodeIterator(Iterator[T]):
             magic_hash = hashlib.new('sha224')
         else:
             # Use blake2b when possible, i.e. on Python >= 3.6.
-            # pylint:disable=no-member
-            magic_hash = hashlib.blake2b(digest_size=6)  # type:ignore
+            magic_hash = hashlib.blake2b(digest_size=6)  # pylint: disable=no-member; type:ignore
         magic_hash.update(json.dumps(
             [self._query_hash, self._query_variables, self._query_referer, self._context.username]
         ).encode())

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -4,8 +4,8 @@ import json
 from collections import namedtuple
 from typing import Any, Callable, Dict, Iterator, Optional, TypeVar
 
-from .exceptions import InvalidArgumentException
-from .instaloadercontext import InstaloaderContext, QueryReturnedBadRequestException
+from .exceptions import InvalidArgumentException, QueryReturnedBadRequestException
+from .instaloadercontext import InstaloaderContext
 
 FrozenNodeIterator = namedtuple('FrozenNodeIterator',
                                 ['query_hash', 'query_variables', 'query_referer', 'context_username',

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -73,7 +73,7 @@ class NodeIterator(Iterator[T]):
                 NodeIterator._graphql_page_length = new_page_length
                 self._context.error("HTTP Error 400 (Bad Request) on GraphQL Query. Retrying with shorter page length.",
                                     repeat_at_end=False)
-                return self._query()
+                return self._query(after)
             else:
                 raise
 

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -58,7 +58,7 @@ class NodeIterator(Iterator[T]):
         self._total_index = 0
 
     def _query(self, after: Optional[str] = None):
-        pagination_variables: Dict[str, Any] = {'first': NodeIterator._graphql_page_length}
+        pagination_variables = {'first': NodeIterator._graphql_page_length}  # type: Dict[str, Any]
         if after is not None:
             pagination_variables['after'] = after
         try:

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -1,0 +1,145 @@
+import base64
+import hashlib
+import json
+from collections import namedtuple
+from typing import Any, Callable, Dict, Iterator, Optional, TypeVar
+
+from .exceptions import InvalidArgumentException
+from .instaloadercontext import InstaloaderContext, QueryReturnedBadRequestException
+
+FrozenNodeIterator = namedtuple('FrozenNodeIterator',
+                                ['query_hash', 'query_variables', 'query_referer', 'context_username',
+                                 'total_index', 'remaining_data'])
+
+T = TypeVar('T')
+
+
+class NodeIterator(Iterator[T]):
+    """
+    Iterate the nodes within edges in a GraphQL pagination.
+
+    What makes this iterator special is its ability to freeze/store its current state, e.g. to interrupt an iteration,
+    and later thaw/resume from where it left off.
+
+    You can freeze a NodeIterator with :meth:`NodeIterator.freeze`::
+
+       post_iterator = profile.get_posts()
+       try:
+           for post in post_iterator:
+               do_something_with(post)
+       except KeyboardInterrupt:
+           save("resume_information.json", post_iterator.freeze())
+
+    and later reuse it with :meth:`NodeIterator.thaw` on an equally-constructed NodeIterator::
+
+       post_iterator = profile.get_posts()
+       post_iterator.thaw(load("resume_information.json"))
+
+    """
+
+    _graphql_page_length = 50
+
+    def __init__(self,
+                 context: InstaloaderContext,
+                 query_hash: str,
+                 edge_extractor: Callable[[Dict[str, Any]], Dict[str, Any]],
+                 node_wrapper: Callable[[Dict], T],
+                 query_variables: Optional[Dict[str, Any]] = None,
+                 query_referer: Optional[str] = None,
+                 first_data: Optional[Dict[str, Any]] = None):
+        self._context = context
+        self._query_hash = query_hash
+        self._edge_extractor = edge_extractor
+        self._node_wrapper = node_wrapper
+        self._query_variables = query_variables if query_variables is not None else {}
+        self._query_referer = query_referer
+        self._data = first_data
+        self._page_index = 0
+        self._total_index = 0
+
+    def _query(self, after: Optional[str] = None):
+        pagination_variables: Dict[str, Any] = {'first': NodeIterator._graphql_page_length}
+        if after is not None:
+            pagination_variables['after'] = after
+        try:
+            return self._edge_extractor(
+                self._context.graphql_query(
+                    self._query_hash, {**self._query_variables, **pagination_variables}, self._query_referer
+                )
+            )
+        except QueryReturnedBadRequestException:
+            new_page_length = int(NodeIterator._graphql_page_length / 2)
+            if new_page_length >= 12:
+                NodeIterator._graphql_page_length = new_page_length
+                self._context.error("HTTP Error 400 (Bad Request) on GraphQL Query. Retrying with shorter page length.",
+                                    repeat_at_end=False)
+                return self._query()
+            else:
+                raise
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._data is None:
+            self._data = self._query()
+        if self._page_index < len(self._data['edges']):
+            node = self._data['edges'][self._page_index]['node']
+            self._page_index += 1
+            self._total_index += 1
+            return self._node_wrapper(node)
+        if self._data['page_info']['has_next_page']:
+            query_response = self._query(self._data['page_info']['end_cursor'])
+            self._page_index = 0
+            self._data = query_response
+            return self.__next__()
+        raise StopIteration()
+
+    @property
+    def count(self) -> Optional[int]:
+        """The ``count`` as returned by Instagram. This is not always the total count this iterator will yield."""
+        return self._data.get('count') if self._data is not None else None
+
+    @property
+    def total_index(self) -> int:
+        """Number of items that have already been returned."""
+        return self._total_index
+
+    @property
+    def magic(self) -> str:
+        """Magic string for easily identifying a matching iterator file for resuming (hash of some parameters)."""
+        if 'blake2b' not in hashlib.algorithms_available:
+            magic_hash = hashlib.new('sha224')
+        else:
+            magic_hash = hashlib.blake2b(digest_size=6)
+        magic_hash.update(json.dumps(
+            [self._query_hash, self._query_variables, self._query_referer, self._context.username]
+        ).encode())
+        return base64.urlsafe_b64encode(magic_hash.digest()).decode()
+
+    def freeze(self) -> FrozenNodeIterator:
+        """Freeze the iterator for later resuming."""
+        remaining_data = None
+        if self._data is not None:
+            remaining_data = {**self._data,
+                              'edges': (self._data['edges'][(max(self._page_index - 1, 0)):])}
+        return FrozenNodeIterator(
+            query_hash=self._query_hash,
+            query_variables=self._query_variables,
+            query_referer=self._query_referer,
+            context_username=self._context.username,
+            total_index=max(self.total_index - 1, 0),
+            remaining_data=remaining_data,
+        )
+
+    def thaw(self, frozen: FrozenNodeIterator):
+        """Use this iterator for resuming from earlier iteration."""
+        if self._total_index or self._page_index:
+            raise InvalidArgumentException("thaw() called on already-used iterator.")
+        if (self._query_hash != frozen.query_hash or
+                self._query_variables != frozen.query_variables or
+                self._query_referer != frozen.query_referer or
+                self._context.username != frozen.context_username):
+            raise InvalidArgumentException("Mismatching resume information.")
+        self._total_index = frozen.total_index
+        self._data = frozen.remaining_data

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -218,11 +218,12 @@ def resumable_iteration(context: InstaloaderContext,
 
     It yields a tuple (is_resuming, start_index).
 
-    When the passed iterator is not a :class:`NodeIterator`, it behaves as if ``resumable_iteration`` was not used.
+    When the passed iterator is not a :class:`NodeIterator`, it behaves as if ``resumable_iteration`` was not used,
+    just executing the inner body.
 
     :param context: The :class:`InstaloaderContext`.
     :param iterator: The fresh :class:`NodeIterator`.
-    :param load: Loads a FrozenNodeIterator from given path. A typecheck is done before the returned object is used.
+    :param load: Loads a FrozenNodeIterator from given path. The object is ignored if it has a different type.
     :param save: Saves the given FrozenNodeIterator to the given path.
     :param format_path: Returns the path to the resume file for the given magic.
     :param check_bbd: Whether to check the best before date and reject an expired FrozenNodeIterator.

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -114,13 +114,23 @@ class NodeIterator(Iterator[T]):
             self._data = self._query()
         if self._page_index < len(self._data['edges']):
             node = self._data['edges'][self._page_index]['node']
-            self._page_index += 1
-            self._total_index += 1
+            page_index, total_index = self._page_index, self._total_index
+            try:
+                self._page_index += 1
+                self._total_index += 1
+            except KeyboardInterrupt:
+                self._page_index, self._total_index = page_index, total_index
+                raise
             return self._node_wrapper(node)
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])
-            self._page_index = 0
-            self._data = query_response
+            page_index, data = self._page_index, self._data
+            try:
+                self._page_index = 0
+                self._data = query_response
+            except KeyboardInterrupt:
+                self._page_index, self._data = page_index, data
+                raise
             return self.__next__()
         raise StopIteration()
 


### PR DESCRIPTION
With this change, Instaloader is capable of resuming a previously-aborted download loop.  To do so, it creates a JSON file within the target directory when interrupted, that contains all the necessary information to later resume that operation.

Resuming an interrupted download is supported for most, but not all targets. It is supported for:
- Regular profile posts,
- IGTV posts
- Saved posts,
- Tagged posts,
- Explore posts.

This supersedes #683 and closes #636.

I consider it ready to be merged, however open for discussion, critics, testing, etc.

<!--
Please describe:

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
