### PR TITLE
Implementation of feature #739

### DIFF
--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -87,8 +87,8 @@ What to Download of each Post
    Download only selected images of a sidecar. You can select single images using their
    index in the sidecar starting with the leftmost or you can specify a range of images
    with the following syntax: ``start_index-end_index``. Example:
-   ``--slide 1`` will select only the first image and ``--slide 1-3`` will select only
-   the first three images.
+   ``--slide 1`` will select only the first image, ``--slide -1`` only the last one and ``--slide 1-3`` will select only
+   the first three images. 
 
 .. option:: --no-metadata-json
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -84,7 +84,11 @@ What to Download of each Post
 
 .. option:: --slide
 
-   Download only selected images of a sidecar.
+   Download only selected images of a sidecar. You can select single images using their
+   index in the sidecar starting with the leftmost or you can specify a range of images
+   with the following syntax: start_index-end_index. Example:
+   ``--slide 1`` will select only the first image and ``--slide 1:3`` will select only
+   the first three images.
 
 .. option:: --no-metadata-json
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -87,7 +87,7 @@ What to Download of each Post
    Download only selected images of a sidecar. You can select single images using their
    index in the sidecar starting with the leftmost or you can specify a range of images
    with the following syntax: ``start_index-end_index``. Example:
-   ``--slide 1`` will select only the first image and ``--slide 1:3`` will select only
+   ``--slide 1`` will select only the first image and ``--slide 1-3`` will select only
    the first three images.
 
 .. option:: --no-metadata-json

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -87,8 +87,8 @@ What to Download of each Post
    Download only selected images of a sidecar. You can select single images using their
    index in the sidecar starting with the leftmost or you can specify a range of images
    with the following syntax: ``start_index-end_index``. Example:
-   ``--slide 1`` will select only the first image, ``--slide -1`` only the last one and ``--slide 1-3`` will select only
-   the first three images. 
+   ``--slide 1`` will select only the first image, ``--slide last`` only the last one and ``--slide 1-3`` will select only
+   the first three images.
 
 .. option:: --no-metadata-json
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -86,7 +86,7 @@ What to Download of each Post
 
    Download only selected images of a sidecar. You can select single images using their
    index in the sidecar starting with the leftmost or you can specify a range of images
-   with the following syntax: start_index-end_index. Example:
+   with the following syntax: ``start_index-end_index``. Example:
    ``--slide 1`` will select only the first image and ``--slide 1:3`` will select only
    the first three images.
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -90,6 +90,8 @@ What to Download of each Post
    ``--slide 1`` will select only the first image, ``--slide last`` only the last one and ``--slide 1-3`` will select only
    the first three images.
 
+   .. versionadded:: 4.6
+
 .. option:: --no-metadata-json
 
    Do not create a JSON file containing the metadata of each post.

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -82,6 +82,10 @@ What to Download of each Post
    Template to write in txt file for each StoryItem. See
    :ref:`metadata-text-files`.
 
+.. option:: --slide
+
+   Download only selected images of a sidecar.
+
 .. option:: --no-metadata-json
 
    Do not create a JSON file containing the metadata of each post.

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -268,6 +268,8 @@ def main():
                         help="Do not download regular posts.")
     g_prof.add_argument('--no-profile-pic', action='store_true',
                         help='Do not download profile picture.')
+    g_prof.add_argument('--slide', action='store',
+                        help='Set what image/interval of a sidecar you want to download')
     g_post.add_argument('--no-pictures', action='store_true',
                         help='Do not download post pictures. Cannot be used together with --fast-update. '
                              'Implies --no-video-thumbnails, does not imply --no-videos.')
@@ -425,7 +427,8 @@ def main():
                              max_connection_attempts=args.max_connection_attempts,
                              request_timeout=args.request_timeout,
                              resume_prefix=resume_prefix,
-                             check_resume_bbd=not args.use_aged_resume_files)
+                             check_resume_bbd=not args.use_aged_resume_files,
+                             slide=args.slide)
         _main(loader,
               args.profile,
               username=args.login.lower() if args.login is not None else None,

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -269,7 +269,7 @@ def main():
     g_prof.add_argument('--no-profile-pic', action='store_true',
                         help='Do not download profile picture.')
     g_prof.add_argument('--slide', action='store',
-                        help='Set what image/interval of a sidecar you want to download')
+                        help='Set what image/interval of a sidecar you want to download.')
     g_post.add_argument('--no-pictures', action='store_true',
                         help='Do not download post pictures. Cannot be used together with --fast-update. '
                              'Implies --no-video-thumbnails, does not imply --no-videos.')

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -268,7 +268,7 @@ def main():
                         help="Do not download regular posts.")
     g_prof.add_argument('--no-profile-pic', action='store_true',
                         help='Do not download profile picture.')
-    g_prof.add_argument('--slide', action='store',
+    g_post.add_argument('--slide', action='store',
                         help='Set what image/interval of a sidecar you want to download.')
     g_post.add_argument('--no-pictures', action='store_true',
                         help='Do not download post pictures. Cannot be used together with --fast-update. '

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -556,7 +556,7 @@ class Instaloader:
         if post.typename == 'GraphSidecar':
             if self.download_pictures or self.download_videos:
                 for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(self.slide_start,
-                                                                              self.slide_end), start=1):
+                                                                                  self.slide_end), start=1):
                     if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
                         suffix = str(edge_number)
                         if '{filename}' in self.filename_pattern:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -217,15 +217,15 @@ class Instaloader:
                     self.slide_start = -1
                 else:
                     if int(splitted[0]) > 0:
-                        self.slide_start = self.slide_end = int(splitted[0])
+                        self.slide_start = self.slide_end = int(splitted[0])-1
                     else:
                         raise InvalidArgumentException("--slide parameter must be greater than 0.")
             elif len(splitted) == 2:
                 if splitted[1] == 'last':
-                    self.slide_start = int(splitted[0])
+                    self.slide_start = int(splitted[0])-1
                 elif 0 < int(splitted[0]) < int(splitted[1]):
-                    self.slide_start = int(splitted[0])
-                    self.slide_end = int(splitted[1])
+                    self.slide_start = int(splitted[0])-1
+                    self.slide_end = int(splitted[1])-1
                 else:
                     raise InvalidArgumentException("Invalid data for --slide parameter.")
             else:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -556,7 +556,7 @@ class Instaloader:
         if post.typename == 'GraphSidecar':
             if self.download_pictures or self.download_videos:
                 for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(self.slide_start,
-                                                                                  self.slide_end), start=1):
+                                                                                  self.slide_end), start=self.slide_start+1):
                     if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
                         suffix = str(edge_number)
                         if '{filename}' in self.filename_pattern:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -220,7 +220,7 @@ class Instaloader:
                 self.slide_start = int(splitted[0])
                 self.slide_end = int(splitted[1])
             else:
-                raise InvalidArgumentException("Invalid data for --slide parameter: ".format(slide))
+                raise InvalidArgumentException("Invalid data for --slide parameter: ")
 
     @contextmanager
     def anonymous_copy(self):

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -208,22 +208,21 @@ class Instaloader:
 
         self.slide = slide or ""
         self.slide_start = 0
-        self.slide_end = 0
+        self.slide_end = -1
         if self.slide != "":
             splitted = self.slide.split('-')
             if len(splitted) == 1:
                 if splitted[0] == 'last':
-                    #download only last image of a sidecar
-                    self.slide_end = -1
+                    # download only last image of a sidecar
+                    self.slide_start = -1
                 else:
                     if int(splitted[0]) > 0:
                         self.slide_start = self.slide_end = int(splitted[0])
                     else:
-                        raise InvalidArgumentException("--slide parameter must be greather than 0.")
+                        raise InvalidArgumentException("--slide parameter must be greater than 0.")
             elif len(splitted) == 2:
                 if splitted[1] == 'last':
                     self.slide_start = int(splitted[0])
-                    self.slide_end = -1
                 elif 0 < int(splitted[0]) < int(splitted[1]):
                     self.slide_start = int(splitted[0])
                     self.slide_end = int(splitted[1])
@@ -231,8 +230,8 @@ class Instaloader:
                     raise InvalidArgumentException("Invalid data for --slide parameter.")
             else:
                 raise InvalidArgumentException("Invalid data for --slide parameter.")
-        else:
-            self.slide_start = 1
+
+
     @contextmanager
     def anonymous_copy(self):
         """Yield an anonymous, otherwise equally-configured copy of an Instaloader instance; Then copy its error log."""

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -555,9 +555,10 @@ class Instaloader:
         downloaded = True
         if post.typename == 'GraphSidecar':
             if self.download_pictures or self.download_videos:
-                for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(self.slide_start,
-                                                                                  self.slide_end),
-                                                           start=self.slide_start+1):
+                for edge_number, sidecar_node in enumerate(
+                        post.get_sidecar_nodes(self.slide_start, self.slide_end),
+                        start=post.mediacount if self.slide_start < 0 else self.slide_start + 1
+                ):
                     if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
                         suffix = str(edge_number)
                         if '{filename}' in self.filename_pattern:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -556,7 +556,8 @@ class Instaloader:
         if post.typename == 'GraphSidecar':
             if self.download_pictures or self.download_videos:
                 for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(self.slide_start,
-                                                                                  self.slide_end), start=self.slide_start+1):
+                                                                                  self.slide_end), 
+                                                                                  start=self.slide_start+1):
                     if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
                         suffix = str(edge_number)
                         if '{filename}' in self.filename_pattern:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -547,7 +547,6 @@ class Instaloader:
                         # Download only last sidecar node
                         if not sidecar_node.is_last:
                             continue
-                        self.context.log("DOWNLOADING LAST OF SIDECAR")
                     # Download picture or video thumbnail
                     if not sidecar_node.is_video or self.download_video_thumbnails is True:
                         downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -157,6 +157,7 @@ class Instaloader:
     :param rate_controller: Generator for a :class:`RateController` to override rate controlling behavior
     :param resume_prefix: :option:`--resume-prefix`, or None for :option:`--no-resume`.
     :param check_resume_bbd: Whether to check the date of expiry of resume files and reject them if expired.
+    :param slide: :option:`--slide`
 
     .. attribute:: context
 
@@ -182,7 +183,8 @@ class Instaloader:
                  request_timeout: Optional[float] = None,
                  rate_controller: Optional[Callable[[InstaloaderContext], RateController]] = None,
                  resume_prefix: Optional[str] = "iterator",
-                 check_resume_bbd: bool = True):
+                 check_resume_bbd: bool = True,
+                 slide: str = ""):
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
                                           request_timeout, rate_controller)
@@ -203,6 +205,23 @@ class Instaloader:
             else storyitem_metadata_txt_pattern
         self.resume_prefix = resume_prefix
         self.check_resume_bbd = check_resume_bbd
+
+        self.slide = slide or ""
+        self.start = 0
+        self.end = 0
+        if self.slide != "":
+            splitted = self.slide.split(':')
+            try:
+                if(len(splitted)==1):
+                    self.start=self.end=int(splitted[0])
+                    if(self.start<0): raise ValueError
+                else:
+                    if(int(splitted[0])<int(splitted[1]) and int(splitted[0])>0):
+                        self.start = int(splitted[0])
+                        self.end = int(splitted[1])
+                    else: raise ValueError
+            except ValueError:
+                raise InvalidArgumentException("Invalid data for --slide parameter")
 
     @contextmanager
     def anonymous_copy(self):
@@ -513,19 +532,29 @@ class Instaloader:
 
         # Download the image(s) / video thumbnail and videos within sidecars if desired
         downloaded = True
-        if post.typename == 'GraphSidecar':
-            for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(), start=1):
-                if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
-                    # Download sidecar picture or video thumbnail (--no-pictures implies --no-video-thumbnails)
-                    downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
-                                                    mtime=post.date_local, filename_suffix=str(edge_number))
-                if sidecar_node.is_video and self.download_videos:
-                    # Download sidecar video if desired
-                    downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
-                                                    mtime=post.date_local, filename_suffix=str(edge_number))
-        elif post.typename == 'GraphImage':
-            # Download picture
-            if self.download_pictures:
+        if self.download_pictures:
+            if post.typename == 'GraphSidecar':
+                edge_number = 1
+                for sidecar_node in post.get_sidecar_nodes():
+                    to_download = True
+                    if(self.start+self.end!=0):
+                        if(edge_number<self.start or edge_number>self.end): to_download=False
+                    
+                    if(to_download):
+                        # Download picture or video thumbnail
+                        if not sidecar_node.is_video or self.download_video_thumbnails is True:
+                            downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
+                                                            mtime=post.date_local, filename_suffix=str(edge_number))
+                        # Additionally download video if available and desired
+                        if sidecar_node.is_video and self.download_videos is True:
+                            downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
+                                                            mtime=post.date_local, filename_suffix=str(edge_number))
+                        self.context.log("Downloading  instagram.com/p/{}/ with index {}".format(post.shortcode,edge_number))
+                    else:
+                        self.context.log("Omitting  instagram.com/p/{}/ with index {} from download".format(post.shortcode,edge_number))
+
+                    edge_number += 1
+            elif post.typename == 'GraphImage':
                 downloaded = self.download_pic(filename=filename, url=post.url, mtime=post.date_local)
         elif post.typename == 'GraphVideo':
             # Download video thumbnail (--no-pictures implies --no-video-thumbnails)

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -213,13 +213,13 @@ class Instaloader:
             splitted = self.slide.split('-')
             if len(splitted) == 1:
                 self.slide_start = self.slide_end = int(splitted[0])
-                if self.slide_start < 0: 
+                if self.slide_start < 0:
                     raise InvalidArgumentException("Invalid data for --slide parameter")
             else:
                 if int(splitted[0]) < int(splitted[1]) and int(splitted[0]) > 0:
                     self.slide_start = int(splitted[0])
                     self.slide_end = int(splitted[1])
-                else: 
+                else:
                     raise InvalidArgumentException("Invalid data for --slide parameter")
 
 
@@ -547,8 +547,7 @@ class Instaloader:
                     if sidecar_node.is_video and self.download_videos is True:
                         downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
                                                         mtime=post.date_local, filename_suffix=str(edge_number))
-                    
-                    self.context.log("Downloading  instagram.com/p/{}/ with index {}".format(post.shortcode, edge_number))
+                    self.context.log("Downloading instagram.com/p/{} with index {}".format(post.shortcode, edge_number))
                     edge_number += 1
             elif post.typename == 'GraphImage':
                 downloaded = self.download_pic(filename=filename, url=post.url, mtime=post.date_local)

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -539,15 +539,14 @@ class Instaloader:
                     if self.slide_start + self.slide_end != 0:
                         if edge_number < self.slide_start or edge_number > self.slide_end:
                             continue
-                    
                     # Download picture or video thumbnail
                     if not sidecar_node.is_video or self.download_video_thumbnails is True:
                         downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
-                                                            mtime=post.date_local, filename_suffix=str(edge_number))
+                                            mtime=post.date_local, filename_suffix=str(edge_number))
                     # Additionally download video if available and desired
                     if sidecar_node.is_video and self.download_videos is True:
                         downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
-                                                            mtime=post.date_local, filename_suffix=str(edge_number))
+                                            mtime=post.date_local, filename_suffix=str(edge_number))
                     
                     self.context.log("Downloading  instagram.com/p/{}/ with index {}".format(post.shortcode, edge_number))
                     edge_number += 1

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -542,11 +542,11 @@ class Instaloader:
                     # Download picture or video thumbnail
                     if not sidecar_node.is_video or self.download_video_thumbnails is True:
                         downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
-                                            mtime=post.date_local, filename_suffix=str(edge_number))
+                                                        mtime=post.date_local, filename_suffix=str(edge_number))
                     # Additionally download video if available and desired
                     if sidecar_node.is_video and self.download_videos is True:
                         downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
-                                            mtime=post.date_local, filename_suffix=str(edge_number))
+                                                        mtime=post.date_local, filename_suffix=str(edge_number))
                     
                     self.context.log("Downloading  instagram.com/p/{}/ with index {}".format(post.shortcode, edge_number))
                     edge_number += 1

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -541,12 +541,12 @@ class Instaloader:
 
         # Download the image(s) / video thumbnail and videos within sidecars if desired
         downloaded = True
-        if self.download_pictures:
-            if post.typename == 'GraphSidecar':
-                edge_number = 1
-                for sidecar_node in post.get_sidecar_nodes(self.slide_start, self.slide_end):
-                    # Download picture or video thumbnail
-                    if not sidecar_node.is_video or self.download_video_thumbnails is True:
+        if post.typename == 'GraphSidecar':
+            if self.download_pictures or self.download_videos:
+                for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(self.slide_start,
+                                                                                  self.slide_end), start=1):
+                    if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
+                        # Download sidecar picture or video thumbnail (--no-pictures implies --no-video-thumbnails)
                         downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
                                                         mtime=post.date_local, filename_suffix=str(edge_number))
                     # Additionally download video if available and desired

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -557,7 +557,7 @@ class Instaloader:
             if self.download_pictures or self.download_videos:
                 for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(self.slide_start,
                                                                                   self.slide_end), 
-                                                                                  start=self.slide_start+1):
+                                                           start=self.slide_start+1):
                     if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
                         suffix = str(edge_number)
                         if '{filename}' in self.filename_pattern:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -184,7 +184,7 @@ class Instaloader:
                  rate_controller: Optional[Callable[[InstaloaderContext], RateController]] = None,
                  resume_prefix: Optional[str] = "iterator",
                  check_resume_bbd: bool = True,
-                 slide: str = ""):
+                 slide: Optional[str] = ""):
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
                                           request_timeout, rate_controller)
@@ -207,21 +207,21 @@ class Instaloader:
         self.check_resume_bbd = check_resume_bbd
 
         self.slide = slide or ""
-        self.start = 0
-        self.end = 0
+        self.slide_start = 0
+        self.slide_end = 0
         if self.slide != "":
-            splitted = self.slide.split(':')
-            try:
-                if(len(splitted)==1):
-                    self.start=self.end=int(splitted[0])
-                    if(self.start<0): raise ValueError
-                else:
-                    if(int(splitted[0])<int(splitted[1]) and int(splitted[0])>0):
-                        self.start = int(splitted[0])
-                        self.end = int(splitted[1])
-                    else: raise ValueError
-            except ValueError:
-                raise InvalidArgumentException("Invalid data for --slide parameter")
+            splitted = self.slide.split('-')
+            if len(splitted) == 1:
+                self.slide_start = self.slide_end = int(splitted[0])
+                if self.slide_start < 0: 
+                    raise InvalidArgumentException("Invalid data for --slide parameter")
+            else:
+                if int(splitted[0]) < int(splitted[1]) and int(splitted[0]) > 0:
+                    self.slide_start = int(splitted[0])
+                    self.slide_end = int(splitted[1])
+                else: 
+                    raise InvalidArgumentException("Invalid data for --slide parameter")
+
 
     @contextmanager
     def anonymous_copy(self):
@@ -536,23 +536,20 @@ class Instaloader:
             if post.typename == 'GraphSidecar':
                 edge_number = 1
                 for sidecar_node in post.get_sidecar_nodes():
-                    to_download = True
-                    if(self.start+self.end!=0):
-                        if(edge_number<self.start or edge_number>self.end): to_download=False
+                    if self.slide_start + self.slide_end != 0:
+                        if edge_number < self.slide_start or edge_number > self.slide_end:
+                            continue
                     
-                    if(to_download):
-                        # Download picture or video thumbnail
-                        if not sidecar_node.is_video or self.download_video_thumbnails is True:
-                            downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
+                    # Download picture or video thumbnail
+                    if not sidecar_node.is_video or self.download_video_thumbnails is True:
+                        downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
                                                             mtime=post.date_local, filename_suffix=str(edge_number))
-                        # Additionally download video if available and desired
-                        if sidecar_node.is_video and self.download_videos is True:
-                            downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
+                    # Additionally download video if available and desired
+                    if sidecar_node.is_video and self.download_videos is True:
+                        downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
                                                             mtime=post.date_local, filename_suffix=str(edge_number))
-                        self.context.log("Downloading  instagram.com/p/{}/ with index {}".format(post.shortcode,edge_number))
-                    else:
-                        self.context.log("Omitting  instagram.com/p/{}/ with index {} from download".format(post.shortcode,edge_number))
-
+                    
+                    self.context.log("Downloading  instagram.com/p/{}/ with index {}".format(post.shortcode, edge_number))
                     edge_number += 1
             elif post.typename == 'GraphImage':
                 downloaded = self.download_pic(filename=filename, url=post.url, mtime=post.date_local)

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -211,16 +211,19 @@ class Instaloader:
         self.slide_end = 0
         if self.slide != "":
             splitted = self.slide.split('-')
-            if len(splitted) == 1:
-                self.slide_start = self.slide_end = int(splitted[0])
-                if self.slide_start < 0:
-                    raise InvalidArgumentException("Invalid data for --slide parameter")
-            else:
-                if int(splitted[0]) < int(splitted[1]) and int(splitted[0]) > 0:
-                    self.slide_start = int(splitted[0])
-                    self.slide_end = int(splitted[1])
+            try:
+                if len(splitted) == 1:
+                    self.slide_start = self.slide_end = int(splitted[0])
+                    if self.slide_start < 0:
+                        raise InvalidArgumentException("Invalid data for --slide parameter")
                 else:
-                    raise InvalidArgumentException("Invalid data for --slide parameter")
+                    if int(splitted[0]) < int(splitted[1]) and int(splitted[0]) > 0:
+                        self.slide_start = int(splitted[0])
+                        self.slide_end = int(splitted[1])
+                    else:
+                        raise InvalidArgumentException("Invalid data for --slide parameter")
+            except:
+                raise InvalidArgumentException("Invalid data for --slide parameter")
 
 
     @contextmanager

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -556,7 +556,7 @@ class Instaloader:
         if post.typename == 'GraphSidecar':
             if self.download_pictures or self.download_videos:
                 for edge_number, sidecar_node in enumerate(post.get_sidecar_nodes(self.slide_start,
-                                                                                  self.slide_end), 
+                                                                                  self.slide_end),
                                                            start=self.slide_start+1):
                     if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
                         suffix = str(edge_number)

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -272,7 +272,8 @@ class Post:
                             orig_url = carousel_media[idx]['image_versions2']['candidates'][0]['url']
                             display_url = re.sub(r'&se=\d+(&?)', r'\1', orig_url)
                         except (InstaloaderException, KeyError, IndexError) as err:
-                            self._context.error('{} Unable to fetch high quality image version of {}.'.format(err, self))
+                            self._context.error('{} Unable to fetch high quality image version of {}.'.format(
+                                err, self))
                     yield PostSidecarNode(is_video=is_video, display_url=display_url,
                                           video_url=node['video_url'] if is_video else None)
 

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -274,7 +274,7 @@ class Post:
                         except (InstaloaderException, KeyError, IndexError) as err:
                             self._context.error('{} Unable to fetch high quality image version of {}.'.format(err, self))
                     yield PostSidecarNode(is_video=is_video, display_url=display_url,
-                                        video_url=node['video_url'] if is_video else None)
+                                          video_url=node['video_url'] if is_video else None)
 
     @property
     def caption(self) -> Optional[str]:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -258,11 +258,11 @@ class Post:
                 # video_url is only present in full metadata, issue #558.
                 edges = self._full_metadata['edge_sidecar_to_children']['edges']
             if end < 0:
-                end = len(edges)
+                end = len(edges)-1
             if start < 0:
-                start = len(edges)
+                start = len(edges)-1
             for idx, edge in enumerate(edges):
-                if start-1 <= idx <= end-1:
+                if start <= idx <= end:
                     node = edge['node']
                     is_video = node['is_video']
                     display_url = node['display_url']

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -11,7 +11,7 @@ from .exceptions import *
 from .instaloadercontext import InstaloaderContext
 from .nodeiterator import FrozenNodeIterator, NodeIterator
 
-PostSidecarNode = namedtuple('PostSidecarNode', ['is_video', 'display_url', 'video_url','is_last'])
+PostSidecarNode = namedtuple('PostSidecarNode', ['is_video', 'display_url', 'video_url', 'is_last'])
 PostSidecarNode.__doc__ = "Item of a Sidecar Post."
 PostSidecarNode.is_video.__doc__ = "Whether this node is a video."
 PostSidecarNode.display_url.__doc__ = "URL of image or video thumbnail."

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -252,8 +252,25 @@ class Post:
         """Type of post, GraphImage, GraphVideo or GraphSidecar"""
         return self._field('__typename')
 
+    @property
+    def mediacount(self) -> int:
+        """
+        The number of media in a sidecar Post, or 1 if the Post it not a sidecar.
+
+        .. versionadded:: 4.6
+        """
+        if self.typename == 'GraphSidecar':
+            edges = self._field('edge_sidecar_to_children', 'edges')
+            return len(edges)
+        return 1
+
     def get_sidecar_nodes(self, start=0, end=-1) -> Iterator[PostSidecarNode]:
-        """Sidecar nodes of a Post with typename==GraphSidecar."""
+        """
+        Sidecar nodes of a Post with typename==GraphSidecar.
+
+        .. versionchanged:: 4.6
+           Added parameters *start* and *end* to specify a slice of sidecar media.
+        """
         if self.typename == 'GraphSidecar':
             edges = self._field('edge_sidecar_to_children', 'edges')
             if any(edge['node']['is_video'] for edge in edges):

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -250,16 +250,16 @@ class Post:
         """Type of post, GraphImage, GraphVideo or GraphSidecar"""
         return self._field('__typename')
 
-    def get_sidecar_nodes(self, start=0, end=0) -> Iterator[PostSidecarNode]:
+    def get_sidecar_nodes(self, start=0, end=-1) -> Iterator[PostSidecarNode]:
         """Sidecar nodes of a Post with typename==GraphSidecar."""
         if self.typename == 'GraphSidecar':
             edges = self._field('edge_sidecar_to_children', 'edges')
             if any(edge['node']['is_video'] for edge in edges):
                 # video_url is only present in full metadata, issue #558.
                 edges = self._full_metadata['edge_sidecar_to_children']['edges']
-            if end <= 0:
+            if end < 0:
                 end = len(edges)
-            if start == 0:
+            if start < 0:
                 start = len(edges)
             for idx, edge in enumerate(edges):
                 if start-1 <= idx <= end-1:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -11,11 +11,12 @@ from .exceptions import *
 from .instaloadercontext import InstaloaderContext
 from .nodeiterator import FrozenNodeIterator, NodeIterator
 
-PostSidecarNode = namedtuple('PostSidecarNode', ['is_video', 'display_url', 'video_url'])
+PostSidecarNode = namedtuple('PostSidecarNode', ['is_video', 'display_url', 'video_url','is_last'])
 PostSidecarNode.__doc__ = "Item of a Sidecar Post."
 PostSidecarNode.is_video.__doc__ = "Whether this node is a video."
 PostSidecarNode.display_url.__doc__ = "URL of image or video thumbnail."
 PostSidecarNode.video_url.__doc__ = "URL of video or None."
+PostSidecarNode.is_last.__doc__ = "Whether this node is the last of the sidecar."
 
 PostCommentAnswer = namedtuple('PostCommentAnswer', ['id', 'created_at_utc', 'text', 'owner', 'likes_count'])
 PostCommentAnswer.id.__doc__ = "ID number of comment."
@@ -261,6 +262,9 @@ class Post:
                 node = edge['node']
                 is_video = node['is_video']
                 display_url = node['display_url']
+                is_last = False
+                if idx == len(edges) - 1:
+                    is_last = True
                 if not is_video and self._context.is_logged_in:
                     try:
                         carousel_media = self._iphone_struct['carousel_media']
@@ -269,7 +273,8 @@ class Post:
                     except (InstaloaderException, KeyError, IndexError) as err:
                         self._context.error('{} Unable to fetch high quality image version of {}.'.format(err, self))
                 yield PostSidecarNode(is_video=is_video, display_url=display_url,
-                                      video_url=node['video_url'] if is_video else None)
+                                      video_url=node['video_url'] if is_video else None,
+                                      is_last=is_last)
 
     @property
     def caption(self) -> Optional[str]:


### PR DESCRIPTION
<!--
Please describe:

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
As said in the title, this pull request is about a **feature implementation** of issue #739. The new change allows to **select which image** or **range of images** to download in an Instagram sidecar.

## Changes 
There's a new parameter, `--slide`, that by default is an empty string. If setted, it allows to:
* download just *one image* with the `index` specified
* download an interval of images, using this format: `start_index`:`end_index`, for example `1:3` (endpoints included)


The core of the new feature is almost entirely implemented inside the `download_post()` method.

### Expected behavior
The index starts from 1, where 1 is the leftmost image in the sidecar. The index numbers can't be negative. If the index/interval is invalid, for example in case you are out of range, the download of the post is *skipped*

## The completeness of this change
* **Is it just a proof of concept?** Yes, it is. Future improvements to this PR will certainly come, but I need to better understand if the purpose of the feature requested on #739 is reached.
* **Is the documentation updated (if appropriate)?** No, it's not.
* **Do you consider it ready to be merged or is it a draft?** As said above, it is not ready to be merged.
* **Can we help you at some point?** Yes, I think so. I would like to have opinions and reviews on the PR, to better understand if this PoC is sufficiently good in order to reach the final purpose of #739.


Please note that I have only tested the feature using Instaloader as a *Python module*, not as a standalone executable.

