### PR TITLE
Add 'title' property to Posts structure 

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -325,6 +325,13 @@ class Post:
         return self._node['is_video']
 
     @property
+    def title(self) -> str:
+        """Title of post, for example from an IGTV video where this can exist."""
+        if "title" in self._node:
+            return self._node["title"]
+        return None
+
+    @property
     def video_url(self) -> Optional[str]:
         """URL of the video, or None."""
         if self.is_video:


### PR DESCRIPTION
Adds `title` property to Posts structure, as these can be found in IGTV post metadata

<!--
Please describe:

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
