### PR TITLE
Avoid additional http request to obtain `owner_id`

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -207,7 +207,13 @@ class Post:
     @property
     def owner_id(self) -> int:
         """The ID of the Post's owner."""
-        return self.owner_profile.userid
+        # The ID may already be available, e.g. if the post instance was created
+        # from an `hashtag.get_posts()` iterator, so no need to make another
+        # http request.
+        if 'owner' in self._node and 'id' in self._node['owner']:
+            return self._node['owner']['id']
+        else:
+            return self.owner_profile.userid
 
     @property
     def date_local(self) -> datetime:


### PR DESCRIPTION
I noticed that a post's `owner_id` is obtained from the respective `owner_profile`. If the `owner_profile` has not been fetched yet, an additional http request is made. However, if the `Post` instance has been created from a `hashtag.get_posts()` iterator, the `owner_id` is already available, and the additional http request is unnecessary. As far as I can see, the PR avoids this unnecessary (and costly) http call.