### PR TITLE
WIP RFC: Sanitize paths also on Linux

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -131,6 +131,10 @@ class _PostPathFormatter(_ArbitraryItemFormatter):
             ret = ret.replace(':', '\uff1a').replace('<', '\ufe64').replace('>', '\ufe65').replace('\"', '\uff02')
             ret = ret.replace('\\', '\ufe68').replace('|', '\uff5c').replace('?', '\ufe16').replace('*', '\uff0a')
             ret = ret.replace('\n', ' ').replace('\r', ' ')
+        if platform.system() == 'Linux':
+            ret = ret.replace(':', '\uff1a').replace('<', '\ufe64').replace('>', '\ufe65').replace('\"', '\uff02')
+            ret = ret.replace('\\', '\ufe68').replace('|', '\uff5c').replace('?', '\ufe16').replace('*', '\uff0a')
+            ret = ret.replace('\n', ' ').replace('\r', ' ')
         return ret
 
 


### PR DESCRIPTION
I download most of my stuff on Linux machines but organize it on Windows machine. I find it most useful if the paths are already in a valid format so I can transfer the directories directly to my Windows partitions.
I would not mind if there is a command line option (like --sanitizepaths) to make the Linux one optional but this is beyond my capabilities.

- A motivation for this change, e.g.
  - More general: What problem does the pull request solve?
Also sanitize the paths on Linux so the data can be transferred to windows without getting invalid data

- The changes proposed in this pull request

- The completeness of this change
  - Do you consider it ready to be merged or is it a draft?
It is more a draft.
  - Can we help you at some point?
Yes, please. It would be better to have a command line options rather to make it default for all users.
