### PR TITLE
Support importing cookies.txt to workaround infinite challenge requests

### DIFF
--- a/docs/codesnippets/615_import_firefox_session_sqlite.py
+++ b/docs/codesnippets/615_import_firefox_session_sqlite.py
@@ -1,8 +1,14 @@
+#!/usr/local/bin/python3
+
 from argparse import ArgumentParser
 from glob import glob
 from os.path import expanduser
 from platform import system
 from sqlite3 import OperationalError, connect
+
+# This script attempts to load Firefox cookies.sqlite file,
+# login to instagram and write the instaloader session file.
+# Try this method if you have trouble logging in using instaloader.
 
 try:
     from instaloader import ConnectionException, Instaloader

--- a/docs/codesnippets/615_import_firefox_session_txt.py
+++ b/docs/codesnippets/615_import_firefox_session_txt.py
@@ -1,0 +1,36 @@
+#!/usr/local/bin/python3
+
+import http.cookiejar
+from argparse import ArgumentParser
+
+# This script attempts to load a cookies.txt file,
+# login to instagram and write the instaloader session file.
+# Try this method if you have trouble logging in using instaloader.
+
+try:
+    from instaloader import ConnectionException, Instaloader
+except ModuleNotFoundError:
+    raise SystemExit("Instaloader not found.\n  pip install [--user] instaloader")
+
+def import_session(cookiefile, sessionfile):
+    print("Using cookies from {}.".format(cookiefile))
+    cj = http.cookiejar.MozillaCookieJar()
+    cj.load(cookiefile, ignore_discard=True, ignore_expires=True)
+    instaloader = Instaloader(max_connection_attempts=1)
+    instaloader.context._session.cookies.update(cj)
+    username = instaloader.test_login()
+    if not username:
+        raise SystemExit("Not logged in. Are you logged in successfully in Firefox?")
+    print("Imported session cookie for {}.".format(username))
+    instaloader.context.username = username
+    instaloader.save_session_to_file(sessionfile)
+
+if __name__ == "__main__":
+    p = ArgumentParser()
+    p.add_argument("-c", "--cookiefile")
+    p.add_argument("-f", "--sessionfile")
+    args = p.parse_args()
+    try:
+        import_session(args.cookiefile, args.sessionfile)
+    except (ConnectionException, OperationalError) as e:
+        raise SystemExit("Cookie import failed: {}".format(e))

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -63,15 +63,15 @@ creates when using :option:`--login`. If a session file is present,
 Also, session files usually do not expire.
 
 If you do not have a session file present, you may use the following script
-(:example:`615_import_firefox_session.py`) to workaround login problems by
+(:example:`615_import_firefox_session_sqlite.py`) or (:example:`615_import_firefox_session_txt.py`) to workaround login problems by
 importing the session cookies from Firefox and bypassing Instaloader's login and
 so still use Instaloader's logged-in functionality.
 
-.. literalinclude:: codesnippets/615_import_firefox_session.py
+.. literalinclude:: codesnippets/615_import_firefox_session_sqlite.py
 
 To use this script,
 
-#. Download the script: :example:`615_import_firefox_session.py`,
+#. Download the script: :example:`615_import_firefox_session_sqlite.py`,
 
 #. Login to Instagram in Firefox,
 
@@ -83,3 +83,6 @@ This script also supports specifying a cookie file path, which may be useful if
 you use multiple Firefox profiles or if your operating system has the directory
 structure differently set up. Also, you can specify an alternative session file
 path.
+
+If this script doesn't work for you (for example because Firefox locks the sqlite file),
+you can alternatively try to export the cookies to a `cookies.txt` file and consume that using :example:`615_import_firefox_session_sqlite.py`.


### PR DESCRIPTION
Same issue as described in the following issues:

#92
#217
#615 

When using instaloader, it asks for a challenge performed in the browser:
> Fatal error: Login: Checkpoint required. Point your browser to https://www.instagram.com/challenge/xxx/yyy/, follow the instructions, then retry.

Been there, done that, only result is that you just get another challenge, forever.

There are code snippet shareds in the issues, and committed in 27b7c98be2beaf8af899d53e7ab30c373872a598 (see  #615).

It loads the Firefox "cookies.sqlite" and writes a new instaloader session file.

However, this snippet doesn't work anymore, because Firefox uses an **exclusive lock**.
Hence sqlite3 cannot read from `cookies.sqlite`, and the script can't function.
For example running `sqlite3 ~/.mozilla/firefox/*/cookies.sqlite` and `SELECT name, value FROM moz_cookies;`.
See also:
https://superuser.com/questions/635317/sqlite-database-browser-fails-to-open-firefox-cookie-database
https://www.sqlite.org/pragma.html#pragma_locking_mode

I'm using Firefox 82.0.3, the lock was introduced probably much sooner.

To work around this issue, I have adapted the script to work with `cookies.txt` files.

To obtain the cookies.txt from Firefox, one can install a plugin, such as this https://addons.mozilla.org/de/firefox/addon/export-cookies-txt/

This is a severe issue for the people affected by the infinite challenge loop, because it makes it impossible to use the program for them.
