### PR TITLE
Added ability to retrieve posts in NodeIterator[Post] since and between given times.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .mypy_cache/
+instaloader.egg-info

--- a/docs/codesnippets.rst
+++ b/docs/codesnippets.rst
@@ -28,21 +28,19 @@ Download Posts in a Specific Period
 -----------------------------------
 
 To only download Instagram pictures (and metadata) that are within a specific
-period, you can simply use :func:`~itertools.dropwhile` and
-:func:`~itertools.takewhile` from :mod:`itertools` on a generator that returns
-Posts in **exact chronological order**, such as :meth:`Profile.get_posts`.
+period, you can simply use :func:`NodeIterator.between` and :func:`NodeIterator.since`.
+Only works with posts in **exact chronological order**, such as :func:`Profile.get_posts`.
 
 .. literalinclude:: codesnippets/121_since_until.py
 
+Or, similarly, to retrieve posts a `timedelta` amount of time since now.
+
+.. literalinclude:: codesnippets/121_since_until_to.py
+
 See also :class:`Post`, :meth:`Instaloader.download_post`.
 
-Discussed in :issue:`121`.
-
-The code example with :func:`~itertools.dropwhile` and
-:func:`~itertools.takewhile` makes the assumption that the post iterator returns
-posts in exact chronological order.  As discussed in :issue:`666`, the following
-approach fits for an **almost chronological order**, where up to *k* older posts
-are inserted into an otherwise chronological order, such as a Hashtag feed.
+As discussed in :issue:`666`, the following approach fits for an **almost chronological order**, 
+where up to *k* older posts are inserted into an otherwise chronological order, such as a Hashtag feed.
 
 .. literalinclude:: codesnippets/666_historical_hashtag_data.py
 

--- a/docs/codesnippets/121_since_until_to.py
+++ b/docs/codesnippets/121_since_until_to.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import timedelta
 import instaloader
 
 L = instaloader.Instaloader()
 profile = instaloader.Profile.from_username(L.context, "instagram")
 posts = profile.get_posts()
 
-for post in posts.between(start=datetime(2020, 11, 27), end=datetime(2020, 11, 30)):
+for post in posts.since(ago=timedelta(days=3)):
     L.download_post(post, "instagram")

--- a/docs/module/nodeiterator.rst
+++ b/docs/module/nodeiterator.rst
@@ -22,6 +22,9 @@ Iterator :class:`NodeIterator` and a context manager
 .. autoclass:: NodeIterator
    :no-show-inheritance:
 
+   .. automethod:: between
+   .. automethod:: since
+
 .. autoclass:: FrozenNodeIterator
    :no-show-inheritance:
 

--- a/instaloader/exceptions.py
+++ b/instaloader/exceptions.py
@@ -58,6 +58,10 @@ class PostChangedException(InstaloaderException):
     pass
 
 
+class IncorrectType(InstaloaderException):
+    pass
+
+
 class QueryReturnedNotFoundException(ConnectionException):
     pass
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -928,6 +928,7 @@ class Instaloader:
             lambda d: d['data']['user']['edge_web_discover_media'],
             lambda n: Post(self.context, n),
             query_referer='https://www.instagram.com/explore/',
+            chronological=False
         )
 
     def get_hashtag_posts(self, hashtag: str) -> Iterator[Post]:

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -262,7 +262,7 @@ class NodeIterator(Iterator[T]):
                 profile = instaloader.Profile.from_username(L.context, "instagram")
                 posts = profile.get_posts()
 
-                for post in posts.to(time=timedelta(days=3)):
+                for post in posts.since(ago=timedelta(days=3)):
                     print(post.date)
         """
         return self.between(start=datetime.today()-ago)

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -265,7 +265,7 @@ class NodeIterator(Iterator[T]):
                 for post in posts.to(time=timedelta(days=3)):
                     print(post.date)
         """
-        return self.between(start = datetime.today() - ago)
+        return self.between(start=datetime.today()-ago)
 
 @contextmanager
 def resumable_iteration(context: InstaloaderContext,

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -237,7 +237,7 @@ class NodeIterator(Iterator[T]):
             end = start + end
 
         if inclusive:
-            end = end.replace(hour=23, minute=59, second=59)
+            end = end.replace(hour=23, minute=59, second=59) # type:ignore
 
         for post in self:
             if post.date > start and post.date > end:

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -203,17 +203,22 @@ class NodeIterator(Iterator[T]):
         self._best_before = datetime.fromtimestamp(frozen.best_before)
         self._data = frozen.remaining_data
 
-    def between(self, start: datetime, end: Optional[Union[datetime, timedelta]] = datetime.max, inclusive: bool = True):
+    def between(self,
+                start: datetime,
+                end: Optional[Union[datetime, timedelta]] = datetime.max,
+                inclusive: bool = True):
         """
-        Use this generator to retrieve Node content between start and end range. Only works for `NodeIterator[Post]` type.
+        Use this generator to retrieve Node content between start and end range. Only works for `NodeIterator[Post]`
+        type.
 
         :param start: Start `datetime` object.
         :param end: End `datetime` or `timedelta` object.
         :param inclusive: Set true by default. Changes behavior from [start, end) to [start, end].
-        :note: If end range is left empty it will default to `datetime.max`. Likewise, if end range is a `timedelta` object, it will default to `start + end`.
-        :example: 
+        :note: If end range is left empty it will default to `datetime.max`. Likewise, if end range is a `timedelta`
+            object, it will default to `start + end`.
+        :example:
             .. code-block:: python
-            
+
                 from datetime import datetime, timedelta
                 import instaloader
 
@@ -245,7 +250,7 @@ class NodeIterator(Iterator[T]):
     def since(self, ago: timedelta):
         """
         Use this generator to retrieve Node content from as far back as the given timedelta `time`.
-        
+
         :param ago: How far back to retrieve posts. Only works for `NodeIterator[Post]` type.
         :example:
             .. code-block:: python
@@ -260,8 +265,8 @@ class NodeIterator(Iterator[T]):
                 for post in posts.to(time=timedelta(days=3)):
                     print(post.date)
         """
-        return self.between(start=datetime.today()-ago)
-    
+        return self.between(start = datetime.today() - ago)
+
 @contextmanager
 def resumable_iteration(context: InstaloaderContext,
                         iterator: Iterator,

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -249,7 +249,7 @@ class NodeIterator(Iterator[T]):
 
     def since(self, ago: timedelta):
         """
-        Use this generator to retrieve Node content from as far back as the given timedelta `time`.
+        Use this generator to retrieve Node content from as far back as the given timedelta `ago`.
 
         :param ago: How far back to retrieve posts. Only works for `NodeIterator[Post]` type.
         :example:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -812,6 +812,7 @@ class Profile:
             {'id': self.userid},
             'https://www.instagram.com/{0}/'.format(self.username),
             self._metadata('edge_owner_to_timeline_media'),
+            True
         )
 
     def get_saved_posts(self) -> NodeIterator[Post]:
@@ -829,6 +830,7 @@ class Profile:
             lambda n: Post(self._context, n),
             {'id': self.userid},
             'https://www.instagram.com/{0}/'.format(self.username),
+            chronological=False
         )
 
     def get_tagged_posts(self) -> NodeIterator[Post]:
@@ -845,6 +847,7 @@ class Profile:
             lambda n: Post(self._context, n, self if int(n['owner']['id']) == self.userid else None),
             {'id': self.userid},
             'https://www.instagram.com/{0}/'.format(self.username),
+            chronological=True
         )
 
     def get_igtv_posts(self) -> NodeIterator[Post]:
@@ -862,6 +865,7 @@ class Profile:
             {'id': self.userid},
             'https://www.instagram.com/{0}/channel/'.format(self.username),
             self._metadata('edge_felix_video_timeline'),
+            chronological=True
         )
 
     def get_followers(self) -> NodeIterator['Profile']:


### PR DESCRIPTION
As discussed in #121, Instaloader does not have the capability out-of-the-box to retrieve posts from a `NodeIterator[Post]` type between dates and as far back from the current time. This pull-request adds those two features by adding two functions, `NodeIterator.between()` and `NodeIterator.since()` which only works with `NodeIterator[Post]` that are chronologically organized (specifically `get_posts`, `get_tagged_posts`, and `get_igtv_posts`). 

### `.between()`

```python
from datetime import datetime, timedelta
import instaloader

L = instaloader.Instaloader()
profile = instaloader.Profile.from_username(L.context, "instagram")
posts = profile.get_posts()

for post in posts.between(start=datetime(2020, 11, 27), end=datetime(2020, 11, 30)):
    print(post.date)
```

### `.since()`

```python
from datetime import datetime, timedelta
import instaloader

L = instaloader.Instaloader()
profile = instaloader.Profile.from_username(L.context, "instagram")
posts = profile.get_posts()

for post in posts.since(ago=timedelta(days=3)):
    print(post.date)
```

## Implementation

To make this possible, a new param `chronological` was added to `NodeIterator`:

```python
class NodeIterator(Iterator[T]):
    def __init__(self,
                 context: InstaloaderContext,
                 query_hash: str,
                 edge_extractor: Callable[[Dict[str, Any]], Dict[str, Any]],
                 node_wrapper: Callable[[Dict], T],
                 query_variables: Optional[Dict[str, Any]] = None,
                 query_referer: Optional[str] = None,
                 first_data: Optional[Dict[str, Any]] = None,
                 chronological: Optional[bool] = None):
        ...
```

This variable is used to make the distinction between those `NodeIterators` that are chronological, and those that are not. All functions in the codebase that returns a `NodeIterator[Post]` were modified.

## Note

Since `Hashtag.get_posts()` returns an `Iterator[Post]` type, this modification will not change this section of the codebase. Instead, it only applies to the `Post` class.

## Help

If anything, I just ask documentation is looked through for any spelling mistakes or improvement. Engrish hard. Besides that, I had a hard time trying to figure out two good words for the functions -- left it as `between` and `since(ago=)`, but any recommendation is welcomed.

## Todo

- [x] Functionality.
- [x] Proper type-hinting.
- [x] Added documentation.
- [x] Fixed PyLint and MyPy complaints.