### PR TITLE
Marks story as seen when downloaded

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -618,6 +618,7 @@ class Instaloader:
             totalcount = user_story.itemcount
             count = 1
             for item in user_story.get_items():
+                if count == 1: item.mark_as_seen()
                 if storyitem_filter is not None and not storyitem_filter(item):
                     self.context.log("<{} skipped>".format(item), flush=True)
                     continue

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -618,7 +618,8 @@ class Instaloader:
             totalcount = user_story.itemcount
             count = 1
             for item in user_story.get_items():
-                if count == 1: item.mark_as_seen()
+                if count == 1:
+                    item.mark_as_seen()
                 if storyitem_filter is not None and not storyitem_filter(item):
                     self.context.log("<{} skipped>".format(item), flush=True)
                     continue

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -973,7 +973,7 @@ class StoryItem:
             'reelMediaTakenAt': int(self.date_local.timestamp()),
             'viewSeenAt': int(seen_at.timestamp()),
         }
-        self._context._session.post('https://www.instagram.com/stories/reel/seen', data=seen)
+        self._context._session.post('https://www.instagram.com/stories/reel/seen', data=seen) # pylint: disable=W0212
 
     @property
     def owner_profile(self) -> Profile:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -963,6 +963,18 @@ class StoryItem:
     def __hash__(self) -> int:
         return hash(self.mediaid)
 
+    def mark_as_seen(self, seen_at: Optional[datetime] = None) -> None:
+        if seen_at is None:
+            seen_at = self.date_local # [sic] website uses taken-at as seen-at
+        seen = {
+            'reelMediaId': self.mediaid,
+            'reelMediaOwnerId': self.owner_id,
+            'reelId': self.owner_id,
+            'reelMediaTakenAt': int(self.date_local.timestamp()),
+            'viewSeenAt': int(seen_at.timestamp()),
+        }
+        self._context._session.post('https://www.instagram.com/stories/reel/seen', data=seen)
+
     @property
     def owner_profile(self) -> Profile:
         """:class:`Profile` instance of the story item's owner."""


### PR DESCRIPTION
<!--
Please describe:

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->

This fixes issue #724, which wasn't able to download every story available to your account because it wasn't marking them as read, and therefore couldn't get the other stories it wasn't showing you. This fixes the issue by marking a story as read as soon as you download it, so the other stories can then be downloaded since Instagram always shows you the unread stories first.

I would consider this to be sufficient in 99% of cases, but an improvement would be if it only marked it as read when accessing the 1st storyitem _and_ it successfully downloads, rather than marking it as read every time the 1st story is accessed, which would help with the mark as read rate limits. I would do it myself, but I'm not good at python, although it doesn't seem like it would be particularly difficult, so any help would be appreciated.

EDIT: [This](https://github.com/e5150/instaloader/commit/2ab43b0705d88baaf0656a3aa3ef09f12acb12f3) commit does it, but I don't know how to do it along with only doing the 1st storyitem of each story.