### PR TITLE
fix 429 Too Many requests: proxy balancer support for public profiles

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -373,7 +373,7 @@ def main():
                         help='Disable user interaction, i.e. do not print messages (except errors) and fail '
                              'if login credentials are needed but not given. This makes Instaloader suitable as a '
                              'cron job.')
-    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', 
+    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY',
                         help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 '
                              'proxy balancer. Should be used without --login and for public accounts downloading only.')
     g_misc.add_argument('-h', '--help', action='help', help='Show this help message and exit.')

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -373,6 +373,7 @@ def main():
                         help='Disable user interaction, i.e. do not print messages (except errors) and fail '
                              'if login credentials are needed but not given. This makes Instaloader suitable as a '
                              'cron job.')
+    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 proxy balancer.')                         
     g_misc.add_argument('-h', '--help', action='help', help='Show this help message and exit.')
     g_misc.add_argument('--version', action='version', help='Show version number and exit.',
                         version=__version__)
@@ -424,7 +425,8 @@ def main():
                              max_connection_attempts=args.max_connection_attempts,
                              request_timeout=args.request_timeout,
                              resume_prefix=resume_prefix,
-                             check_resume_bbd=not args.use_aged_resume_files)
+                             check_resume_bbd=not args.use_aged_resume_files,
+                             rapidapi_key=args.rapidapi_key)
         _main(loader,
               args.profile,
               username=args.login.lower() if args.login is not None else None,

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -373,7 +373,8 @@ def main():
                         help='Disable user interaction, i.e. do not print messages (except errors) and fail '
                              'if login credentials are needed but not given. This makes Instaloader suitable as a '
                              'cron job.')
-    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 proxy balancer. Should be used without --login and for public accounts downloading only.')                         
+    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 ' 
+                             'proxy balancer. Should be used without --login and for public accounts downloading only.')
     g_misc.add_argument('-h', '--help', action='help', help='Show this help message and exit.')
     g_misc.add_argument('--version', action='version', help='Show version number and exit.',
                         version=__version__)

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -373,7 +373,7 @@ def main():
                         help='Disable user interaction, i.e. do not print messages (except errors) and fail '
                              'if login credentials are needed but not given. This makes Instaloader suitable as a '
                              'cron job.')
-    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 proxy balancer.')                         
+    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 proxy balancer. Should be used without --login and for public accounts downloading only.')                         
     g_misc.add_argument('-h', '--help', action='help', help='Show this help message and exit.')
     g_misc.add_argument('--version', action='version', help='Show version number and exit.',
                         version=__version__)

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -373,7 +373,8 @@ def main():
                         help='Disable user interaction, i.e. do not print messages (except errors) and fail '
                              'if login credentials are needed but not given. This makes Instaloader suitable as a '
                              'cron job.')
-    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 ' 
+    g_misc.add_argument('--rapidapi-key', metavar='SECRET_KEY', 
+                        help='RapidAPI key for https://rapidapi.com/restyler/api/instagram40 '
                              'proxy balancer. Should be used without --login and for public accounts downloading only.')
     g_misc.add_argument('-h', '--help', action='help', help='Show this help message and exit.')
     g_misc.add_argument('--version', action='version', help='Show version number and exit.',

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -182,10 +182,11 @@ class Instaloader:
                  request_timeout: Optional[float] = None,
                  rate_controller: Optional[Callable[[InstaloaderContext], RateController]] = None,
                  resume_prefix: Optional[str] = "iterator",
-                 check_resume_bbd: bool = True):
+                 check_resume_bbd: bool = True,
+                 rapidapi_key: Optional[str] = None):
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
-                                          request_timeout, rate_controller)
+                                          request_timeout, rate_controller, rapidapi_key)
 
         # configuration parameters
         self.dirname_pattern = dirname_pattern or "{target}"

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -54,7 +54,8 @@ class InstaloaderContext:
 
     def __init__(self, sleep: bool = True, quiet: bool = False, user_agent: Optional[str] = None,
                  max_connection_attempts: int = 3, request_timeout: Optional[float] = None,
-                 rate_controller: Optional[Callable[["InstaloaderContext"], "RateController"]] = None, rapidapi_key: Optional[str] = None):
+                 rate_controller: Optional[Callable[["InstaloaderContext"], "RateController"]] = None, 
+                 rapidapi_key: Optional[str] = None):
 
         self.user_agent = user_agent if user_agent is not None else default_user_agent()
         self.request_timeout = request_timeout
@@ -321,9 +322,9 @@ class InstaloaderContext:
             if is_other_query:
                 self._rate_controller.wait_before_query('other')
 
-            if (self.rapidapi_key):
+            if self.rapidapi_key:
                 url = "https://instagram40.p.rapidapi.com/proxy"
-                proxy_params = { 'url': 'https://{0}/{1}'.format(host, path) + '?' + urllib.parse.urlencode(params)}
+                proxy_params = {'url': 'https://{0}/{1}'.format(host, path) + '?' + urllib.parse.urlencode(params)}
                 headers = {
                     'x-rapidapi-key': self.rapidapi_key,
                     'x-rapidapi-host': "instagram40.p.rapidapi.com"

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -54,7 +54,7 @@ class InstaloaderContext:
 
     def __init__(self, sleep: bool = True, quiet: bool = False, user_agent: Optional[str] = None,
                  max_connection_attempts: int = 3, request_timeout: Optional[float] = None,
-                 rate_controller: Optional[Callable[["InstaloaderContext"], "RateController"]] = None, 
+                 rate_controller: Optional[Callable[["InstaloaderContext"], "RateController"]] = None,
                  rapidapi_key: Optional[str] = None):
 
         self.user_agent = user_agent if user_agent is not None else default_user_agent()


### PR DESCRIPTION
Fixes 429 rate limit via optional proxy balancer support.
Uses https://rapidapi.com/restyler/api/instagram40 balancer.

Fixes:
https://github.com/instaloader/instaloader/issues/933
https://github.com/instaloader/instaloader/issues/922
https://github.com/instaloader/instaloader/issues/946
https://github.com/instaloader/instaloader/issues/918
https://github.com/instaloader/instaloader/issues/883
https://github.com/instaloader/instaloader/issues/886
and many other cases.

Should be used (and was tested) for public profiles download.

Demo:
![image](https://user-images.githubusercontent.com/775507/103315213-6baf2400-4a3e-11eb-91aa-81a062966266.png)


