### PR TITLE
Added method to get title of post

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -121,7 +121,9 @@ class Post:
     @property
     def title(self) -> Optional[str]:
         """Title of post"""
-        return self._full_metadata_dict.get("title", None)
+        if "title" in self._full_metadata_dict:
+            return self._full_metadata_dict["title"]
+        return None
 
     @property
     def shortcode(self) -> str:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -119,6 +119,11 @@ class Post:
         return node
 
     @property
+    def title(self) -> Optional[str]:
+        """Title of post"""
+        return self._full_metadata_dict.get("title", None)
+
+    @property
     def shortcode(self) -> str:
         """Media shortcode. URL of the post is instagram.com/p/<shortcode>/."""
         return self._node['shortcode'] if 'shortcode' in self._node else self._node['code']


### PR DESCRIPTION
On behalf of issue [#969](https://github.com/instaloader/instaloader/issues/969)

-- A motivation for this change
  - Fixes # 
  - Some post of instagram has title as same as caption but current version of instaloader does not give title of post.
  - To get title of post, I've added one property method called title as same as caption method in class Post.

-- The completeness of this change
 - In json response of graphql query, it gives title of post with key name as title as same as location in value of shortcode_media 
   but instaloader was not considering it.
 - Added one method named _title_ in class _Post_ which will get value of title from __full_metadata_dict_  dictionary variable.
 - If title is not present in json response, it will return None.
 - Need to update documentation for this method.
 - I consider it for ready to be merged.
 - Please guide me if necessary.

Example of use case:

`from instaloader.instaloader import Instaloader, Post`
`L = Instaloader()`
`post = Post.from_shortcode(L.context, "CKA_09eMMVE")`
`print("Title of Post : ", post.title)`
