### PR TITLE
Add method to get title of post (#969)

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -128,6 +128,13 @@ class Post:
         """The mediaid is a decimal representation of the media shortcode."""
         return int(self._node['id'])
 
+    @property
+    def title(self) -> Optional[str]:
+        """Title of post"""
+        if "title" in self._full_metadata_dict:
+            return self._full_metadata_dict["title"]
+        return None
+
     def __repr__(self):
         return '<Post {}>'.format(self.shortcode)
 

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -131,9 +131,10 @@ class Post:
     @property
     def title(self) -> Optional[str]:
         """Title of post"""
-        if "title" in self._full_metadata_dict:
-            return self._full_metadata_dict["title"]
-        return None
+        try:
+            return self._field('title')
+        except KeyError:
+            return None
 
     def __repr__(self):
         return '<Post {}>'.format(self.shortcode)


### PR DESCRIPTION
For the solution of issue [#969](https://github.com/instaloader/instaloader/issues/969)

-- A motivation for this change
  - Fixes # 
  - Some post of instagram has title as same as caption but current version of instaloader does not give title of post.
  - To get title of post, I've added one property method called title as same as caption method in class Post.

-- The completeness of this change
 - In json response of graphql query, it gives title of post with key name as title as same as location in value of shortcode_media 
   but instaloader was not considering it.
 - Added one method named _title_ in class _Post_ which will get value of title from __full_metadata_dict_  dictionary.
 - If title is not present in json response, it will return None.
 - Need to update documentation for this method.
 - I consider it for ready to be merged.
 - Please guide me if necessary.

- Example of use case:

`from instaloader.instaloader import Instaloader, Post`
`L = Instaloader()`
`post = Post.from_shortcode(L.context, "CKA_09eMMVE")`
`print("Title of Post : ", post.title)`
