### PR TITLE
Resumable Iteration info saved on any exception

### DIFF
--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -262,7 +262,7 @@ def resumable_iteration(context: InstaloaderContext,
             context.error("Warning: Not resuming from {}: {}".format(resume_file_path, exc))
     try:
         yield is_resuming, start_index
-    except KeyboardInterrupt:
+    except:
         if os.path.dirname(resume_file_path):
             os.makedirs(os.path.dirname(resume_file_path), exist_ok=True)
         save(iterator.freeze(), resume_file_path)


### PR DESCRIPTION
Feature enhancement:
When resumable iteration is interrupted by some other exceptions other than KeyboardInterrupt  (e.g. login redirect)  iteration state is not saved.  (issue  #986)

Change in this pull request:
Resumable_iteration now intercepts any exception occurred during iteration (not only KeyboardInterrupt ).

I have tested it locally and works as expected.
If accepted probably a note in documentation would be needed.
