### PR TITLE
Reload graphsidecar json

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -577,7 +577,7 @@ class Instaloader:
                 if post.has_sidecar_video:
                     postloaded = self.load_metadata_json(filename)
                     if postloaded is Post:
-                        post = postloaded
+                        post = cast(Post, postloaded)
                 for edge_number, sidecar_node in enumerate(
                         post.get_sidecar_nodes(self.slide_start, self.slide_end),
                         start=post.mediacount if self.slide_start < 0 else self.slide_start + 1

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -289,7 +289,7 @@ class Instaloader:
         os.utime(filename, (datetime.now().timestamp(), mtime.timestamp()))
         return True
 
-    def load_metadata_json(self, filename: str) -> JsonExportable:
+    def load_metadata_json(self, filename: str) -> Optional[JsonExportable]:
         """Load metadata JSON file of a structure."""
         fn = filename + '.json.xz'
         if Path(fn).is_file():
@@ -576,7 +576,7 @@ class Instaloader:
             if self.download_pictures or self.download_videos:
                 if post.has_sidecar_video:
                     postloaded = self.load_metadata_json(filename)
-                    if postloaded is not None:
+                    if postloaded is Post:
                         post = postloaded
                 for edge_number, sidecar_node in enumerate(
                         post.get_sidecar_nodes(self.slide_start, self.slide_end),

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -566,6 +566,27 @@ class Instaloader:
         :return: True if something was downloaded, False otherwise, i.e. file was already there
         """
 
+        def _already_downloaded(path: str) -> bool:
+            if not os.path.isfile(path):
+                return False
+            else:
+                self.context.log(path + ' exists', end=' ', flush=True)
+                return True
+
+        def _all_already_downloaded(path_base, is_videos_enumerated) -> bool:
+            if '{filename}' in self.filename_pattern:
+                # full URL needed to evaluate actual filename, cannot determine at
+                # this point if all sidecar nodes were already downloaded.
+                return False
+            for idx, is_video in is_videos_enumerated:
+                if self.download_pictures and (not is_video or self.download_video_thumbnails):
+                    if not _already_downloaded("{0}_{1}.jpg".format(path_base, idx)):
+                        return False
+                if is_video and self.download_videos:
+                    if not _already_downloaded("{0}_{1}.mp4".format(path_base, idx)):
+                        return False
+            return True
+
         dirname = _PostPathFormatter(post).format(self.dirname_pattern, target=target)
         filename_template = os.path.join(dirname, self.format_filename(post, target=target))
         filename = self.__prepare_filename(filename_template, lambda: post.url)
@@ -578,37 +599,45 @@ class Instaloader:
                     postloaded = self.load_metadata_json(filename)
                     if postloaded is Post:
                         post = cast(Post, postloaded)
+                if not _all_already_downloaded(
+                        filename_template, enumerate(
+                            (post.get_is_videos()[i]
+                             for i in range(self.slide_start % post.mediacount, self.slide_end % post.mediacount + 1)),
+                            start=self.slide_start % post.mediacount + 1
+                        )
+                ):
                 for edge_number, sidecar_node in enumerate(
                         post.get_sidecar_nodes(self.slide_start, self.slide_end),
-                        start=post.mediacount if self.slide_start < 0 else self.slide_start + 1
+                            start=self.slide_start % post.mediacount + 1
                 ):
-                    if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
-                        suffix = str(edge_number)
+                        suffix = str(edge_number)  # type: Optional[str]
                         if '{filename}' in self.filename_pattern:
-                            suffix = ''
+                            suffix = None
+                    if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
                         # pylint:disable=cell-var-from-loop
                         filename2 = self.__prepare_filename(filename_template, lambda: sidecar_node.display_url)
                         # Download sidecar picture or video thumbnail (--no-pictures implies --no-video-thumbnails)
                         downloaded &= self.download_pic(filename=filename2, url=sidecar_node.display_url,
                                                         mtime=post.date_local, filename_suffix=suffix)
                     if sidecar_node.is_video and self.download_videos:
-                        suffix = str(edge_number)
-                        if '{filename}' in self.filename_pattern:
-                            suffix = ''
                         # pylint:disable=cell-var-from-loop
                         filename2 = self.__prepare_filename(filename_template, lambda: sidecar_node.video_url)
                         # Download sidecar video if desired
                         downloaded &= self.download_pic(filename=filename2, url=sidecar_node.video_url,
                                                         mtime=post.date_local, filename_suffix=suffix)
+                else:
+                    downloaded = False
         elif post.typename == 'GraphImage':
             # Download picture
             if self.download_pictures:
-                downloaded = self.download_pic(filename=filename, url=post.url, mtime=post.date_local)
+                downloaded = (not _already_downloaded(filename + ".jpg") and
+                              self.download_pic(filename=filename, url=post.url, mtime=post.date_local))
         elif post.typename == 'GraphVideo':
             # Download video thumbnail (--no-pictures implies --no-video-thumbnails)
             if self.download_pictures and self.download_video_thumbnails:
                 with self.context.error_catcher("Video thumbnail of {}".format(post)):
-                    downloaded = self.download_pic(filename=filename, url=post.url, mtime=post.date_local)
+                    downloaded = (not _already_downloaded(filename + ".jpg") and
+                                  self.download_pic(filename=filename, url=post.url, mtime=post.date_local))
         else:
             self.context.error("Warning: {0} has unknown typename: {1}".format(post, post.typename))
 
@@ -619,7 +648,8 @@ class Instaloader:
 
         # Download video if desired
         if post.is_video and self.download_videos:
-            downloaded &= self.download_pic(filename=filename, url=post.video_url, mtime=post.date_local)
+            downloaded &= (not _already_downloaded(filename + ".mp4") and
+                           self.download_pic(filename=filename, url=post.video_url, mtime=post.date_local))
 
         # Download geotags if desired
         if self.download_geotags and post.location:
@@ -712,17 +742,25 @@ class Instaloader:
         :return: True if something was downloaded, False otherwise, i.e. file was already there
         """
 
+        def _already_downloaded(path: str) -> bool:
+            if not os.path.isfile(path):
+                return False
+            else:
+                self.context.log(path + ' exists', end=' ', flush=True)
+                return True
+
         date_local = item.date_local
         dirname = _PostPathFormatter(item).format(self.dirname_pattern, target=target)
         filename_template = os.path.join(dirname, self.format_filename(item, target=target))
         filename = self.__prepare_filename(filename_template, lambda: item.url)
         downloaded = False
         if not item.is_video or self.download_video_thumbnails is True:
-            url = item.url
-            downloaded = self.download_pic(filename=filename, url=url, mtime=date_local)
+            downloaded = (not _already_downloaded(filename + ".jpg") and
+                          self.download_pic(filename=filename, url=item.url, mtime=date_local))
         if item.is_video and self.download_videos is True:
             filename = self.__prepare_filename(filename_template, lambda: str(item.video_url))
-            downloaded |= self.download_pic(filename=filename, url=item.video_url, mtime=date_local)
+            downloaded |= (not _already_downloaded(filename + ".mp4") and
+                           self.download_pic(filename=filename, url=item.video_url, mtime=date_local))
         # Save caption if desired
         metadata_string = _ArbitraryItemFormatter(item).format(self.storyitem_metadata_txt_pattern).strip()
         if metadata_string:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -606,25 +606,25 @@ class Instaloader:
                             start=self.slide_start % post.mediacount + 1
                         )
                 ):
-                for edge_number, sidecar_node in enumerate(
-                        post.get_sidecar_nodes(self.slide_start, self.slide_end),
+                    for edge_number, sidecar_node in enumerate(
+                            post.get_sidecar_nodes(self.slide_start, self.slide_end),
                             start=self.slide_start % post.mediacount + 1
-                ):
+                    ):
                         suffix = str(edge_number)  # type: Optional[str]
                         if '{filename}' in self.filename_pattern:
                             suffix = None
-                    if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
-                        # pylint:disable=cell-var-from-loop
-                        filename2 = self.__prepare_filename(filename_template, lambda: sidecar_node.display_url)
-                        # Download sidecar picture or video thumbnail (--no-pictures implies --no-video-thumbnails)
-                        downloaded &= self.download_pic(filename=filename2, url=sidecar_node.display_url,
-                                                        mtime=post.date_local, filename_suffix=suffix)
-                    if sidecar_node.is_video and self.download_videos:
-                        # pylint:disable=cell-var-from-loop
-                        filename2 = self.__prepare_filename(filename_template, lambda: sidecar_node.video_url)
-                        # Download sidecar video if desired
-                        downloaded &= self.download_pic(filename=filename2, url=sidecar_node.video_url,
-                                                        mtime=post.date_local, filename_suffix=suffix)
+                        if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
+                            # pylint:disable=cell-var-from-loop
+                            filename2 = self.__prepare_filename(filename_template, lambda: sidecar_node.display_url)
+                            # Download sidecar picture or video thumbnail (--no-pictures implies --no-video-thumbnails)
+                            downloaded &= self.download_pic(filename=filename2, url=sidecar_node.display_url,
+                                                            mtime=post.date_local, filename_suffix=suffix)
+                        if sidecar_node.is_video and self.download_videos:
+                            # pylint:disable=cell-var-from-loop
+                            filename2 = self.__prepare_filename(filename_template, lambda: sidecar_node.video_url)
+                            # Download sidecar video if desired
+                            downloaded &= self.download_pic(filename=filename2, url=sidecar_node.video_url,
+                                                            mtime=post.date_local, filename_suffix=suffix)
                 else:
                     downloaded = False
         elif post.typename == 'GraphImage':

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -551,27 +551,6 @@ class Instaloader:
         :return: True if something was downloaded, False otherwise, i.e. file was already there
         """
 
-        def _already_downloaded(path: str) -> bool:
-            if not os.path.isfile(path):
-                return False
-            else:
-                self.context.log(path + ' exists', end=' ', flush=True)
-                return True
-
-        def _all_already_downloaded(path_base, is_videos_enumerated) -> bool:
-            if '{filename}' in self.filename_pattern:
-                # full URL needed to evaluate actual filename, cannot determine at
-                # this point if all sidecar nodes were already downloaded.
-                return False
-            for idx, is_video in is_videos_enumerated:
-                if self.download_pictures and (not is_video or self.download_video_thumbnails):
-                    if not _already_downloaded("{0}_{1}.jpg".format(path_base, idx)):
-                        return False
-                if is_video and self.download_videos:
-                    if not _already_downloaded("{0}_{1}.mp4".format(path_base, idx)):
-                        return False
-            return True
-
         dirname = _PostPathFormatter(post).format(self.dirname_pattern, target=target)
         filename_template = os.path.join(dirname, self.format_filename(post, target=target))
         filename = self.__prepare_filename(filename_template, lambda: post.url)
@@ -580,45 +559,37 @@ class Instaloader:
         downloaded = True
         if post.typename == 'GraphSidecar':
             if self.download_pictures or self.download_videos:
-                if not _all_already_downloaded(
-                        filename_template, enumerate(
-                            (post.get_is_videos()[i]
-                             for i in range(self.slide_start % post.mediacount, self.slide_end % post.mediacount + 1)),
-                            start=self.slide_start % post.mediacount + 1
-                        )
+                for edge_number, sidecar_node in enumerate(
+                        post.get_sidecar_nodes(self.slide_start, self.slide_end),
+                        start=post.mediacount if self.slide_start < 0 else self.slide_start + 1
                 ):
-                    for edge_number, sidecar_node in enumerate(
-                            post.get_sidecar_nodes(self.slide_start, self.slide_end),
-                            start=self.slide_start % post.mediacount + 1
-                    ):
-                        suffix = str(edge_number)  # type: Optional[str]
+                    if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
+                        suffix = str(edge_number)
                         if '{filename}' in self.filename_pattern:
-                            suffix = None
-                        if self.download_pictures and (not sidecar_node.is_video or self.download_video_thumbnails):
-                            # pylint:disable=cell-var-from-loop
-                            filename = self.__prepare_filename(filename_template, lambda: sidecar_node.display_url)
-                            # Download sidecar picture or video thumbnail (--no-pictures implies --no-video-thumbnails)
-                            downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
-                                                            mtime=post.date_local, filename_suffix=suffix)
-                        if sidecar_node.is_video and self.download_videos:
-                            # pylint:disable=cell-var-from-loop
-                            filename = self.__prepare_filename(filename_template, lambda: sidecar_node.video_url)
-                            # Download sidecar video if desired
-                            downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
-                                                            mtime=post.date_local, filename_suffix=suffix)
-                else:
-                    downloaded = False
+                            suffix = ''
+                        # pylint:disable=cell-var-from-loop
+                        filename = self.__prepare_filename(filename_template, lambda: sidecar_node.display_url)
+                        # Download sidecar picture or video thumbnail (--no-pictures implies --no-video-thumbnails)
+                        downloaded &= self.download_pic(filename=filename, url=sidecar_node.display_url,
+                                                        mtime=post.date_local, filename_suffix=suffix)
+                    if sidecar_node.is_video and self.download_videos:
+                        suffix = str(edge_number)
+                        if '{filename}' in self.filename_pattern:
+                            suffix = ''
+                        # pylint:disable=cell-var-from-loop
+                        filename = self.__prepare_filename(filename_template, lambda: sidecar_node.video_url)
+                        # Download sidecar video if desired
+                        downloaded &= self.download_pic(filename=filename, url=sidecar_node.video_url,
+                                                        mtime=post.date_local, filename_suffix=suffix)
         elif post.typename == 'GraphImage':
             # Download picture
             if self.download_pictures:
-                downloaded = (not _already_downloaded(filename + ".jpg") and
-                              self.download_pic(filename=filename, url=post.url, mtime=post.date_local))
+                downloaded = self.download_pic(filename=filename, url=post.url, mtime=post.date_local)
         elif post.typename == 'GraphVideo':
             # Download video thumbnail (--no-pictures implies --no-video-thumbnails)
             if self.download_pictures and self.download_video_thumbnails:
                 with self.context.error_catcher("Video thumbnail of {}".format(post)):
-                    downloaded = (not _already_downloaded(filename + ".jpg") and
-                                  self.download_pic(filename=filename, url=post.url, mtime=post.date_local))
+                    downloaded = self.download_pic(filename=filename, url=post.url, mtime=post.date_local)
         else:
             self.context.error("Warning: {0} has unknown typename: {1}".format(post, post.typename))
 
@@ -629,8 +600,7 @@ class Instaloader:
 
         # Download video if desired
         if post.is_video and self.download_videos:
-            downloaded &= (not _already_downloaded(filename + ".mp4") and
-                           self.download_pic(filename=filename, url=post.video_url, mtime=post.date_local))
+            downloaded &= self.download_pic(filename=filename, url=post.video_url, mtime=post.date_local)
 
         # Download geotags if desired
         if self.download_geotags and post.location:
@@ -723,25 +693,17 @@ class Instaloader:
         :return: True if something was downloaded, False otherwise, i.e. file was already there
         """
 
-        def _already_downloaded(path: str) -> bool:
-            if not os.path.isfile(path):
-                return False
-            else:
-                self.context.log(path + ' exists', end=' ', flush=True)
-                return True
-
         date_local = item.date_local
         dirname = _PostPathFormatter(item).format(self.dirname_pattern, target=target)
         filename_template = os.path.join(dirname, self.format_filename(item, target=target))
         filename = self.__prepare_filename(filename_template, lambda: item.url)
         downloaded = False
         if not item.is_video or self.download_video_thumbnails is True:
-            downloaded = (not _already_downloaded(filename + ".jpg") and
-                          self.download_pic(filename=filename, url=item.url, mtime=date_local))
+            url = item.url
+            downloaded = self.download_pic(filename=filename, url=url, mtime=date_local)
         if item.is_video and self.download_videos is True:
             filename = self.__prepare_filename(filename_template, lambda: str(item.video_url))
-            downloaded |= (not _already_downloaded(filename + ".mp4") and
-                           self.download_pic(filename=filename, url=item.video_url, mtime=date_local))
+            downloaded |= self.download_pic(filename=filename, url=item.video_url, mtime=date_local)
         # Save caption if desired
         metadata_string = _ArbitraryItemFormatter(item).format(self.storyitem_metadata_txt_pattern).strip()
         if metadata_string:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -272,17 +272,6 @@ class Post:
             return len(edges)
         return 1
 
-    def get_is_videos(self) -> List[bool]:
-        """
-        Return a list containing the ``is_video`` property for each media in the post.
-
-        .. versionadded:: 4.7
-        """
-        if self.typename == 'GraphSidecar':
-            edges = self._field('edge_sidecar_to_children', 'edges')
-            return [edge['node']['is_video'] for edge in edges]
-        return [self.is_video]
-
     def get_sidecar_nodes(self, start=0, end=-1) -> Iterator[PostSidecarNode]:
         """
         Sidecar nodes of a Post with typename==GraphSidecar.
@@ -292,13 +281,13 @@ class Post:
         """
         if self.typename == 'GraphSidecar':
             edges = self._field('edge_sidecar_to_children', 'edges')
+            if any(edge['node']['is_video'] for edge in edges):
+                # video_url is only present in full metadata, issue #558.
+                edges = self._full_metadata['edge_sidecar_to_children']['edges']
             if end < 0:
                 end = len(edges)-1
             if start < 0:
                 start = len(edges)-1
-            if any(self.get_is_videos()[start:(end+1)]):
-                # video_url is only present in full metadata, issue #558.
-                edges = self._full_metadata['edge_sidecar_to_children']['edges']
             for idx, edge in enumerate(edges):
                 if start <= idx <= end:
                     node = edge['node']

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -288,6 +288,17 @@ class Post:
                 return True
         return False
 
+    def get_is_videos(self) -> List[bool]:
+        """
+        Return a list containing the ``is_video`` property for each media in the post.
+
+        .. versionadded:: 4.7
+        """
+        if self.typename == 'GraphSidecar':
+            edges = self._field('edge_sidecar_to_children', 'edges')
+            return [edge['node']['is_video'] for edge in edges]
+        return [self.is_video]
+
     def get_sidecar_nodes(self, start=0, end=-1) -> Iterator[PostSidecarNode]:
         """
         Sidecar nodes of a Post with typename==GraphSidecar.
@@ -297,13 +308,13 @@ class Post:
         """
         if self.typename == 'GraphSidecar':
             edges = self._field('edge_sidecar_to_children', 'edges')
-            if any(edge['node']['is_video'] for edge in edges):
-                # video_url is only present in full metadata, issue #558.
-                edges = self._full_metadata['edge_sidecar_to_children']['edges']
             if end < 0:
                 end = len(edges)-1
             if start < 0:
                 start = len(edges)-1
+            if any(self.get_is_videos()[start:(end+1)]):
+                # video_url is only present in full metadata, issue #558.
+                edges = self._full_metadata['edge_sidecar_to_children']['edges']
             for idx, edge in enumerate(edges):
                 if start <= idx <= end:
                     node = edge['node']

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -153,8 +153,7 @@ class Post:
         if not self._full_metadata_dict:
             pic_json = self._context.graphql_query(
                 'a9441f24ac73000fa17fe6e6da11d59d',
-                {'shortcode': self.shortcode},
-                "https://www.instagram.com/p/(0)/".format(self.shortcode)
+                {'shortcode': self.shortcode}
             )
             self._full_metadata_dict = pic_json['data']['shortcode_media']
             self._node['is_loaded_graphsidecar'] = '1'

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -152,7 +152,7 @@ class Post:
     def _obtain_metadata(self):
         if not self._full_metadata_dict:
             pic_json = self._context.graphql_query(
-                'a9441f24ac73000fa17fe6e6da11d59d',
+                '2b0673e0dc4580674a88d426fe00ea90',
                 {'shortcode': self.shortcode}
             )
             self._full_metadata_dict = pic_json['data']['shortcode_media']
@@ -870,7 +870,7 @@ class Profile:
         self._obtain_metadata()
         return NodeIterator(
             self._context,
-            '003056d32c2554def87228bc3fd9668a',
+            '472f257a40c653c64c666ce877d59d2b',
             lambda d: d['data']['user']['edge_owner_to_timeline_media'],
             lambda n: Post(self._context, n, self),
             {'id': self.userid},


### PR DESCRIPTION
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Implement feature issue #999
  - More general: What problem does the pull request solve?
    Load existing GraphSidecar json instead of downloading again. Previously for every GraphSidecar node that had videos in it, a graph query was executed even the json has been already downloaded before.

- The changes proposed in this pull request
    Instead of downloading that json again, just load it from disk if it has been downloaded and saved before.

- The completeness of this change
  - Is it just a proof of concept? _No_
  - Is the documentation updated (if appropriate)? _not needed_
  - Do you consider it ready to be merged or is it a draft? _ready_
  - Can we help you at some point? _please review_
