### PR TITLE
Update the query_hash for post downloads

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -835,7 +835,7 @@ class Profile:
         self._obtain_metadata()
         return NodeIterator(
             self._context,
-            '472f257a40c653c64c666ce877d59d2b',
+            '003056d32c2554def87228bc3fd9668a',
             lambda d: d['data']['user']['edge_owner_to_timeline_media'],
             lambda n: Post(self._context, n, self),
             {'id': self.userid},


### PR DESCRIPTION
- It's necessary because for the old query_hash IG isn't returning the full structure any more.
- So the old query_hash is replaced with the current one.

Urls are from [https://www.instagram.com/cats_of_instagram/](https://www.instagram.com/cats_of_instagram/).

This one is currently used in Instaloader:
[https://www.instagram.com/graphql/query/?query_hash=472f257a40c653c64c666ce877d59d2b&variables=%7B%22id%22%3A%227013409%22%2C%22first%22%3A50%2C%22after%22%3A%22QVFBNmlPTlE4YU15U0R1X1otUVNuSFVxY3M2QWVqbWlfcFBVVGNyY0NQeFR4Nkp6RVR3Vl9TV016T3UyY3kyTm1Ib2h2NGw5aDBXc3dMUmFiVWY5M0J3Vg%3D%3D%22%7D](https://www.instagram.com/graphql/query/?query_hash=472f257a40c653c64c666ce877d59d2b&variables=%7B%22id%22%3A%227013409%22%2C%22first%22%3A50%2C%22after%22%3A%22QVFBNmlPTlE4YU15U0R1X1otUVNuSFVxY3M2QWVqbWlfcFBVVGNyY0NQeFR4Nkp6RVR3Vl9TV016T3UyY3kyTm1Ib2h2NGw5aDBXc3dMUmFiVWY5M0J3Vg%3D%3D%22%7D)

Now look here at the current one from the website:
[https://www.instagram.com/graphql/query/?query_hash=003056d32c2554def87228bc3fd9668a&variables=%7B%22id%22%3A%227013409%22%2C%22first%22%3A50%2C%22after%22%3A%22QVFBNmlPTlE4YU15U0R1X1otUVNuSFVxY3M2QWVqbWlfcFBVVGNyY0NQeFR4Nkp6RVR3Vl9TV016T3UyY3kyTm1Ib2h2NGw5aDBXc3dMUmFiVWY5M0J3Vg%3D%3D%22%7D](https://www.instagram.com/graphql/query/?query_hash=003056d32c2554def87228bc3fd9668a&variables=%7B%22id%22%3A%227013409%22%2C%22first%22%3A50%2C%22after%22%3A%22QVFBNmlPTlE4YU15U0R1X1otUVNuSFVxY3M2QWVqbWlfcFBVVGNyY0NQeFR4Nkp6RVR3Vl9TV016T3UyY3kyTm1Ib2h2NGw5aDBXc3dMUmFiVWY5M0J3Vg%3D%3D%22%7D)

Especially look on node indexes 3 (GraphSidecar, CLAIIh5lwWa) and 4 (GraphVideo, CK_znJ_nxYa).
