### PR TITLE
Fixed Profile Command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ To **download all pictures and videos of a profile**, as well as the
 
 ::
 
-    instaloader profile [profile ...]
+    instaloader [profile ...]
 
 where ``profile`` is the name of a profile you want to download. Instead
 of only one profile, you may also specify a list of profiles.


### PR DESCRIPTION
The word profile is no longer required, this simply searches for an Instagram profile with the username of "profile" instead of being an argument



<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
