### PR TITLE
Adding feature to retrieve source files URLs instead of downloading them

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -574,6 +574,15 @@ class Instaloader:
         .. versionadded:: 4.1"""
         return _PostPathFormatter(item).format(self.filename_pattern, target=target)
 
+    def fetch_post_caption(self, post: Post) -> str:
+        """
+        Get post's caption
+
+        :param post: Post to fetch its caption.
+        :return: Caption of the post in string format.
+        """
+        metadata_string = _ArbitraryItemFormatter(post).format(self.post_metadata_txt_pattern).strip()
+        return metadata_string
 
     def fetch_post_src_urls(self, post: Post) -> List((str, str)):
         """

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -870,7 +870,7 @@ class Instaloader:
 
         return sources
 
-    def fetch_story_item_src_url(self, item: StoryItem) -> List[Tuple[str, Optional[str]]]:
+    def fetch_story_item_src_url(self, item: StoryItem) -> List[Tuple[str, str]]:
         """Download one user story.
 
         :param item: Story item, as in story['items'] for story in :meth:`get_stories`
@@ -882,8 +882,7 @@ class Instaloader:
         else:
             if self.download_video_thumbnails:
                 sources.append(("thumbnail", item.url))
-            if item.is_video and self.download_videos is True:
-                sources.append(("video", item.video_url))
+            sources.append(("video", item.video_url))
         self.context.log()
         return sources
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -846,7 +846,7 @@ class Instaloader:
         :param userids: List of user IDs or Profiles to be processed in terms of downloading their stories
         :param storyitem_filter: function(storyitem), which returns True if given StoryItem should be downloaded
         :raises LoginRequiredException: If called without being logged in.
-        :return: a list of tuple of format (str, str), first item is type of the story: (image/video/thumbnail) the second item is its source url
+        :return: first item is type of the story: (image/video/thumbnail) the second item is its source url
         """
         sources = []
         if not userids:
@@ -874,7 +874,7 @@ class Instaloader:
         """Download one user story.
 
         :param item: Story item, as in story['items'] for story in :meth:`get_stories`
-        :return: a list of tuple of format (str, str), first item is type of the story: (image/video/thumbnail) the second item is its source url
+        :return: first item is type of the story: (image/video/thumbnail) the second item is its source url
         """
         sources = []
         if not item.is_video:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -593,10 +593,7 @@ class Instaloader:
         """
         sources = []
         if post.typename == 'GraphSidecar':
-            for edge_number, sidecar_node in enumerate(
-                    post.get_sidecar_nodes(self.slide_start, self.slide_end),
-                    start=self.slide_start % post.mediacount + 1
-            ):
+            for sidecar_node in post.get_sidecar_nodes(self.slide_start, self.slide_end):
                 if (not sidecar_node.is_video or self.download_video_thumbnails):
                     # pylint:disable=cell-var-from-loop
                     url=sidecar_node.display_url

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -875,6 +875,25 @@ class Instaloader:
                     if fast_update and not downloaded:
                         break
         return sources
+
+    def fetch_story_item_src_url(self, item: StoryItem) -> List[(str, str)]:
+        """Download one user story.
+
+        :param item: Story item, as in story['items'] for story in :meth:`get_stories`
+        :return: a list of tuple of format (str, str), first item is type of the story: (image/video/thumbnail)
+        the second item is its source url
+        """
+        sources = []
+        if not item.is_video:
+            sources.append(("image", item.url))
+        else:
+            if self.download_video_thumbnails:
+                sources.append(("thumbnail", item.url))
+            if item.is_video and self.download_videos is True:
+                sources.append(("video", item.video_url))
+        self.context.log()
+        return sources
+
     @_requires_login
     def get_highlights(self, user: Union[int, Profile]) -> Iterator[Highlight]:
         """Get all highlights from a user.

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -839,15 +839,14 @@ class Instaloader:
                         userids: Optional[List[Union[int, Profile]]] = None,
                         storyitem_filter: Optional[Callable[[StoryItem], bool]] = None) -> List[Tuple[str, str]]:
         """
-        Download available stories from user followees or all stories of users whose ID are given.
+        Get source urls of available stories from user followees or all stories of users whose ID are given.
         Does not mark stories as seen.
         To use this, one needs to be logged in
 
         :param userids: List of user IDs or Profiles to be processed in terms of downloading their stories
         :param storyitem_filter: function(storyitem), which returns True if given StoryItem should be downloaded
         :raises LoginRequiredException: If called without being logged in.
-        :return: a list of tuple of format (str, str), first item is type of the story: (image/video/thumbnail)
-        the second item is its source url
+        :return: a list of tuple of format (str, str), first item is type of the story: (image/video/thumbnail) the second item is its source url
         """
         sources = []
         if not userids:
@@ -875,8 +874,7 @@ class Instaloader:
         """Download one user story.
 
         :param item: Story item, as in story['items'] for story in :meth:`get_stories`
-        :return: a list of tuple of format (str, str), first item is type of the story: (image/video/thumbnail)
-        the second item is its source url
+        :return: a list of tuple of format (str, str), first item is type of the story: (image/video/thumbnail) the second item is its source url
         """
         sources = []
         if not item.is_video:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -870,7 +870,7 @@ class Instaloader:
 
         return sources
 
-    def fetch_story_item_src_url(self, item: StoryItem) -> List[Tuple[str, str]]:
+    def fetch_story_item_src_url(self, item: StoryItem) -> List[Tuple[str, Optional[str]]]:
         """Download one user story.
 
         :param item: Story item, as in story['items'] for story in :meth:`get_stories`

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -882,7 +882,7 @@ class Instaloader:
         else:
             if self.download_video_thumbnails:
                 sources.append(("thumbnail", item.url))
-            sources.append(("video", item.video_url))
+            sources.append(("video", item.video_url if item.video_url else ""))
         self.context.log()
         return sources
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -13,7 +13,7 @@ from functools import wraps
 from hashlib import md5
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Callable, IO, Iterator, List, Optional, Set, Union, cast
+from typing import Any, Callable, IO, Iterator, List, Optional, Set, Union, cast, Tuple
 from urllib.parse import urlparse
 
 import requests
@@ -584,7 +584,7 @@ class Instaloader:
         metadata_string = _ArbitraryItemFormatter(post).format(self.post_metadata_txt_pattern).strip()
         return metadata_string
 
-    def fetch_post_src_urls(self, post: Post) -> List[(str, str)]:
+    def fetch_post_src_urls(self, post: Post) -> List[Tuple[str, str]]:
         """
         Get post source file urls on the instagram servers.
 
@@ -840,7 +840,7 @@ class Instaloader:
     @_requires_login
     def fetch_stories_src_urls(self,
                         userids: Optional[List[Union[int, Profile]]] = None,
-                        storyitem_filter: Optional[Callable[[StoryItem], bool]] = None) -> List[(str, str)]:
+                        storyitem_filter: Optional[Callable[[StoryItem], bool]] = None) -> List[Tuple[str, str]]:
         """
         Download available stories from user followees or all stories of users whose ID are given.
         Does not mark stories as seen.
@@ -872,11 +872,9 @@ class Instaloader:
                 with self.context.error_catcher('Download story from user {}'.format(name)):
                     sources += self.fetch_story_item_src_url(item)
 
-                    if fast_update and not downloaded:
-                        break
         return sources
 
-    def fetch_story_item_src_url(self, item: StoryItem) -> List[(str, str)]:
+    def fetch_story_item_src_url(self, item: StoryItem) -> List[Tuple[str, str]]:
         """Download one user story.
 
         :param item: Story item, as in story['items'] for story in :meth:`get_stories`

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1206,7 +1206,7 @@ class Story:
         """Retrieve all items from a story."""
         yield from (StoryItem(self._context, item, self.owner_profile) for item in reversed(self._node['items']))
 
-    def get_story_item_from_shortcode(self, shortcode: str) -> StoryItem:
+    def get_story_item_from_shortcode(self, shortcode: str) -> Optional[StoryItem]:
         """Gets a story shortcode url and returns the story item associated with that shortcode.
 
         :param shortcode: shortcode of the story item

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1206,6 +1206,17 @@ class Story:
         """Retrieve all items from a story."""
         yield from (StoryItem(self._context, item, self.owner_profile) for item in reversed(self._node['items']))
 
+    def get_story_item_from_shortcode(self, shortcode: str) -> StoryItem:
+        """Gets a story shortcode url and returns the story item associated with that shortcode.
+
+        :param shortcode: shortcode of the story item
+        :return: a story item associated with the shortcode, None if the story item does not exist.
+        """
+        for item in self.get_items():
+            if item.shortcode == shortcode:
+                return item
+        return None
+
 
 class Highlight(Story):
     """


### PR DESCRIPTION


- A motivation for this change, e.g.
  - More general: What problem does the pull request solve?
  previously there weren't any methods inside the Instaloader class to let us retrieve the files' source URLs, but here I added some methods to add this functionality. It is helpful because sometimes it is not efficient to download the files and we can just place the posts' source URLs inside our code.

- The changes proposed in this pull request
  added fetch_post_src_urls
  added fetch_post_caption
  added fetch_stories_src_urls
  added fetch_story_item_from_shortcode

- The completeness of this change
  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? Yes
  - Do you consider it ready to be merged or is it a draft? I recommend merging it 
  - Can we help you at some point? Yes, please review.