### PR TITLE
Show progress of scraping

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -736,10 +736,16 @@ class Instaloader:
             self.context.log("Retrieving all visible stories...")
         else:
             userids = [p if isinstance(p, int) else p.userid for p in userids]
+            profile_count = len(userids)
 
-        for user_story in self.get_stories(userids):
+        for i, user_story in enumerate(self.get_stories(userids), start=1):
             name = user_story.owner_username
-            self.context.log("Retrieving stories from profile {}.".format(name))
+            if profile_count is not None:
+                msg = "[{0:{w}d}/{1:{w}d}] Retrieving stories from profile {2}.".format(i, profile_count, name,
+                                                                                        w=len(str(profile_count)))
+            else:
+                msg = "[{:3d}] Retrieving stories from profile {}.".format(i, name)
+            self.context.log(msg)
             totalcount = user_story.itemcount
             count = 1
             for item in user_story.get_items():
@@ -1246,7 +1252,9 @@ class Instaloader:
         # error_handler type is Callable[[Optional[str]], ContextManager[None]] (not supported with Python 3.5.0..3.5.3)
         error_handler = _error_raiser if raise_errors else self.context.error_catcher
 
-        for profile in profiles:
+        for i, profile in enumerate(profiles, start=1):
+            self.context.log("[{0:{w}d}/{1:{w}d}] Downloading profile {2}".format(i, len(profiles), profile.username,
+                                                                                  w=len(str(len(profiles)))))
             with error_handler(profile.username):  # type: ignore # (ignore type for Python 3.5 support)
                 profile_name = profile.username
 


### PR DESCRIPTION
**What problem does the pull request solve?** Since profiles are not downloaded in the order specified in the command line (and if one downloads followees, one doesn't even know which profiles will be downloaded), it's not possible to know the progress of the scraping process.

**Changes**: This changes the log lines "Retrieving stories from profile..." and "Downloading profile" to include a counter ##/## showing the current profile number and the total (if known).

**Is it just a proof of concept?** I believe it's complete
**Is the documentation updated (if appropriate)?** Doesn't apply
**Do you consider it ready to be merged or is it a draft?** I believe it's ready
**Can we help you at some point?** It's a small change, but nevertheless feel free to suggest improvements.
