### PR TITLE
Use --filename-pattern for profile pics and covers

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -149,27 +149,37 @@ target. The default is ``--dirname-pattern={target}``. In the dirname
 pattern, the token ``{target}`` is replaced by the target name, and
 ``{profile}`` is replaced by the owner of the post which is downloaded.
 
-:option:`--filename-pattern` configures the path of the post's files relative
+:option:`--filename-pattern` configures the path of the post and story's files relative
 to the target directory that is specified with :option:`--dirname-pattern`.
 The default is ``--filename-pattern={date_utc}_UTC``.
 The tokens ``{target}`` and ``{profile}`` are replaced like in the
-dirname pattern. The following tokens are defined for usage with
-:option:`--filename-pattern`:
+dirname pattern.
+
+:option:`--title-pattern` is similar to :option:`--filename-pattern`, but for profile
+pics, hashtag profile pics, and highlight covers. The default is
+``{date_utc}_UTC_{typename}`` if :option:`--dirname-pattern` contains ``{target}`` or
+``{profile}``, or ``{target}_{date_utc}_UTC_{typename}`` if it does not. Some tokens
+are not supported for this option, see below for details.
+
+The following tokens are defined for usage with
+:option:`--filename-pattern` and :option:`--title-pattern`:
 
 - ``{target}``
    Target name (as given in Instaloader command line)
 
 - ``{profile}`` (same as ``{owner_username}``)
-   Owner of the Post / StoryItem.
+   Owner of the Post / StoryItem / ProfilePic. For hashtag profile pics and
+   highlight covers, equivalent to ``{target}``.
 
 - ``{owner_id}``
-   Unique integer ID of owner profile.
+   Unique integer ID of owner profile. For hashtag profile pics and highlight covers,
+   equivalent to ``{target}``.
 
 - ``{shortcode}``
-   Shortcode (identifier string).
+   Shortcode (identifier string). Not available for :option:`--title-pattern`.
 
 - ``{mediaid}``
-   Integer representation of shortcode.
+   Integer representation of shortcode. Not available for :option:`--title-pattern`.
 
 - ``{filename}``
    Instagram's internal filename.

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -172,8 +172,8 @@ The following tokens are defined for usage with
    highlight covers, equivalent to ``{target}``.
 
 - ``{owner_id}``
-   Unique integer ID of owner profile. For hashtag profile pics and highlight covers,
-   equivalent to ``{target}``.
+   Unique integer ID of owner profile. For hashtag profile pics, equivalent to
+   ``{target}``.
 
 - ``{shortcode}``
    Shortcode (identifier string). Not available for :option:`--title-pattern`.
@@ -191,6 +191,10 @@ The following tokens are defined for usage with
    Instaloader is::
 
       {date_utc:%Y-%m-%d_%H-%M-%S}
+
+- ``{typename}``
+   Type of media being saved, such as GraphImage, GraphStoryVideo, profile_pic,
+   etc.
 
 For example, encode the poster's profile name in the filenames with::
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -205,11 +205,22 @@ How to Download
 
 .. option:: --filename-pattern FILENAME_PATTERN
 
-   Prefix of filenames, relative to the directory given with
+   Prefix of filenames for posts and stories, relative to the directory given with
    :option:`--dirname-pattern`. ``{profile}`` is replaced by the profile name,
    ``{target}`` is replaced by the target you specified, i.e.  either ``:feed``,
    ``#hashtag`` or the profile name. Defaults to ``{date_utc}_UTC``.
    See :ref:`filename-specification` for a list of supported tokens.
+
+.. option:: --title-pattern TITLE_PATTERN
+
+   Prefix of filenames for profile pics, hashtag profile pics, and highlight
+   covers, relative to the directory given with :option:`--dirname-pattern`.
+   Defaults to ``{date_utc}_UTC_{typename}`` if :option:`--dirname-pattern`
+   contains ``{target}`` or ``{profile}``, otherwise defaults to
+   ``{target}_{date_utc}_UTC_{typename}``.
+   See :ref:`filename-specification` for a list of supported tokens.
+
+   .. versionadded:: 4.8
 
 .. option:: --resume-prefix prefix
 

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -359,10 +359,13 @@ def main():
                             '{target} is replaced by the target you specified, i.e. either :feed, #hashtag or the '
                             'profile name. Defaults to \'{target}\'.')
     g_how.add_argument('--filename-pattern',
-                       help='Prefix of filenames, relative to the directory given with '
+                       help='Prefix of filenames for posts and stores, relative to the directory given with '
                             '--dirname-pattern. {profile} is replaced by the profile name,'
                             '{target} is replaced by the target you specified, i.e. either :feed'
                             '#hashtag or the profile name. Defaults to \'{date_utc}_UTC\'')
+    g_how.add_argument('--title-pattern',
+                       help='Prefix of filenames for profile pics, hashtag profile pics, and highlight covers. '
+                            'Defaults to \'{date_utc}_UTC_{typename}\'.')
     g_how.add_argument('--resume-prefix', metavar='PREFIX',
                        help='Prefix for filenames that are used to save the information to resume an interrupted '
                             'download.')
@@ -432,6 +435,7 @@ def main():
 
         loader = Instaloader(sleep=not args.no_sleep, quiet=args.quiet, user_agent=args.user_agent,
                              dirname_pattern=args.dirname_pattern, filename_pattern=args.filename_pattern,
+                             title_pattern=args.title_pattern,
                              download_pictures=not args.no_pictures,
                              download_videos=not args.no_videos, download_video_thumbnails=not args.no_video_thumbnails,
                              download_geotags=args.geotags,

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -359,13 +359,15 @@ def main():
                             '{target} is replaced by the target you specified, i.e. either :feed, #hashtag or the '
                             'profile name. Defaults to \'{target}\'.')
     g_how.add_argument('--filename-pattern',
-                       help='Prefix of filenames for posts and stores, relative to the directory given with '
+                       help='Prefix of filenames for posts and stories, relative to the directory given with '
                             '--dirname-pattern. {profile} is replaced by the profile name,'
                             '{target} is replaced by the target you specified, i.e. either :feed'
                             '#hashtag or the profile name. Defaults to \'{date_utc}_UTC\'')
     g_how.add_argument('--title-pattern',
                        help='Prefix of filenames for profile pics, hashtag profile pics, and highlight covers. '
-                            'Defaults to \'{date_utc}_UTC_{typename}\'.')
+                            'Defaults to \'{date_utc}_UTC_{typename}\' if --dirname-pattern contains \'{target}\' '
+                            'or \'{dirname}\', or if --dirname-pattern is not specified. Otherwise defaults to '
+                            '\'{target}_{date_utc}_UTC_{typename}\'.')
     g_how.add_argument('--resume-prefix', metavar='PREFIX',
                        help='Prefix for filenames that are used to save the information to resume an interrupted '
                             'download.')
@@ -435,7 +437,6 @@ def main():
 
         loader = Instaloader(sleep=not args.no_sleep, quiet=args.quiet, user_agent=args.user_agent,
                              dirname_pattern=args.dirname_pattern, filename_pattern=args.filename_pattern,
-                             title_pattern=args.title_pattern,
                              download_pictures=not args.no_pictures,
                              download_videos=not args.no_videos, download_video_thumbnails=not args.no_video_thumbnails,
                              download_geotags=args.geotags,
@@ -449,7 +450,8 @@ def main():
                              check_resume_bbd=not args.use_aged_resume_files,
                              slide=args.slide,
                              fatal_status_codes=args.abort_on,
-                             iphone_support=not args.no_iphone)
+                             iphone_support=not args.no_iphone,
+                             title_pattern=args.title_pattern)
         _main(loader,
               args.profile,
               username=args.login.lower() if args.login is not None else None,

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -10,7 +10,6 @@ import tempfile
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from functools import wraps
-from hashlib import md5
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, IO, Iterator, List, Optional, Set, Union, cast

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -177,7 +177,6 @@ class Instaloader:
                  user_agent: Optional[str] = None,
                  dirname_pattern: Optional[str] = None,
                  filename_pattern: Optional[str] = None,
-                 title_pattern: Optional[str] = None,
                  download_pictures=True,
                  download_videos: bool = True,
                  download_video_thumbnails: bool = True,
@@ -194,7 +193,8 @@ class Instaloader:
                  check_resume_bbd: bool = True,
                  slide: Optional[str] = None,
                  fatal_status_codes: Optional[List[int]] = None,
-                 iphone_support: bool = True):
+                 iphone_support: bool = True,
+                 title_pattern: Optional[str] = None):
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
                                           request_timeout, rate_controller, fatal_status_codes,

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1548,15 +1548,15 @@ class _TitlePic:
         self._date_utc = date_utc
 
     @property
-    def profile(self) -> str:
+    def profile(self) -> Union[str, Path]:
         return self._profile.username.lower() if self._profile is not None else self._target
 
     @property
-    def owner_username(self) -> str:
+    def owner_username(self) -> Union[str, Path]:
         return self.profile
 
     @property
-    def owner_id(self) -> str:
+    def owner_id(self) -> Union[str, Path]:
         return str(self._profile.userid) if self._profile is not None else self._target
 
     @property

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -4,6 +4,7 @@ import re
 from base64 import b64decode, b64encode
 from collections import namedtuple
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
 
 from . import __version__
@@ -1535,6 +1536,60 @@ class TopSearchResults:
         The string that was searched for on Instagram to produce this :class:`TopSearchResults` instance.
         """
         return self._searchstring
+
+
+class _TitlePic:
+    def __init__(self, profile: Optional[Profile], target: Union[str, Path], typename: str,
+                 filename: str, date_utc: Optional[datetime]):
+        self._profile = profile
+        self._target = target
+        self._typename = typename
+        self._filename = filename
+        self._date_utc = date_utc
+
+    @property
+    def profile(self) -> str:
+        return self._profile.username.lower() if self._profile is not None else self._target
+
+    @property
+    def owner_username(self) -> str:
+        return self.profile
+
+    @property
+    def owner_id(self) -> str:
+        return str(self._profile.userid) if self._profile is not None else self._target
+
+    @property
+    def target(self) -> Union[str, Path]:
+        return self._target
+
+    @property
+    def typename(self) -> str:
+        return self._typename
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+
+    @property
+    def date_utc(self) -> Optional[datetime]:
+        return self._date_utc
+
+    @property
+    def date(self) -> Optional[datetime]:
+        return self.date
+
+    @property
+    def date_local(self) -> Optional[datetime]:
+        return self._date_utc.astimezone() if self._date_utc is not None else None
+
+    @property
+    def shortcode(self) -> str:
+        return self._typename
+
+    @property
+    def mediaid(self) -> str:
+        return self._typename
 
 
 JsonExportable = Union[Post, Profile, StoryItem, Hashtag, FrozenNodeIterator]

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1538,7 +1538,7 @@ class TopSearchResults:
         return self._searchstring
 
 
-class _TitlePic:
+class TitlePic:
     def __init__(self, profile: Optional[Profile], target: Union[str, Path], typename: str,
                  filename: str, date_utc: Optional[datetime]):
         self._profile = profile
@@ -1582,14 +1582,6 @@ class _TitlePic:
     @property
     def date_local(self) -> Optional[datetime]:
         return self._date_utc.astimezone() if self._date_utc is not None else None
-
-    @property
-    def shortcode(self) -> str:
-        return self._typename
-
-    @property
-    def mediaid(self) -> str:
-        return self._typename
 
 
 JsonExportable = Union[Post, Profile, StoryItem, Hashtag, FrozenNodeIterator]

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1577,7 +1577,7 @@ class TitlePic:
 
     @property
     def date(self) -> Optional[datetime]:
-        return self.date
+        return self.date_utc
 
     @property
     def date_local(self) -> Optional[datetime]:


### PR DESCRIPTION
Currently profile pics are saved with a fixed filename template, that doesn't even include the owner's name.

This changes the behaviour so that when saving profile pics, highlight covers and hashtag profile pics, the filename is created based on `--filename-template`.

Not all tokens have meaningful values: there is not `shortcode` or `mediaid`, for example. They're replaced with other values or with an empty string. But all tokens listed in the documentation are supported (and some extra ones that might be useful).

**Is it just a proof of concept?** No
**Is the documentation updated (if appropriate)?** I don't think there is anything to add to the documentation, but I'll certainly add if someone believes it needs to be updated.
**Do you consider it ready to be merged or is it a draft?** It's not a draft, and should be ready, but also see the question below.
**Can we help you at some point?** I'm not sure the way I implemented the feature is optimal. I created a "private" class `_TitlePic` (it's only used internally, and of no use to someone that loads instaloder as a library), but perhaps it should not be in `structures.py`. Feel free the review the code and suggest changes.