### PR TITLE
--latest-stamps, like --fast-update, but without the need to keep downloaded files (Fixes #1122)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,16 @@ To later **update your local copy** of that profiles, you may run
 If ``--fast-update`` is given, Instaloader stops when arriving at the
 first already-downloaded picture.
 
+Alternatively, you can use ``--latest-stamps`` to have Instaloader store
+the time each profile was last downloaded and only download newer media:
+
+::
+
+    instaloader --latest-stamps -- profile [profile ...]
+
+With this option it's possible to move or delete downloaded media and still keep
+the archive updated.
+
 When updating profiles, Instaloader
 automatically **detects profile name changes** and renames the target directory
 accordingly.

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -39,6 +39,16 @@ To later **update your local copy** of that profiles, you may run
 If :option:`--fast-update` is given, Instaloader stops when arriving at the
 first already-downloaded picture.
 
+Alternatively, you can use :option:`--latest-stamps` to have Instaloader store
+the time each profile was last downloaded and only download newer media:
+
+::
+
+    instaloader --latest-stamps -- profile [profile ...]
+
+With this option it's possible to move or delete downloaded media and still keep
+the archive updated.
+
 When updating profiles, Instaloader
 automatically **detects profile name changes** and renames the target directory
 accordingly.

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -150,8 +150,8 @@ Which Posts to Download
 
    Works similarly to :option:`--fast-update`, but instead of relying on already
    downloaded media, the time each profile was downloaded is stored, and only
-   media newer poster after the last download is fetched. This allows updating
-   your personal Instagram archive while emptying the target directories.
+   media newer than the last download is fetched. This allows updating your
+   personal Instagram archive while emptying the target directories.
 
    Only works for media associated with a specific profile, and that is returned
    in chronological order: profile posts, profile stories, profile IGTV posts

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -146,6 +146,23 @@ Which Posts to Download
    This flag is recommended when you use Instaloader to update your personal
    Instagram archive.
 
+.. option:: --latest-stamps [STAMPSFILE]
+
+   Works similarly to :option:`--fast-update`, but instead of relying on already
+   downloaded media, the time each profile was downloaded is stored, and only
+   media newer poster after the last download is fetched. This allows updating
+   your personal Instagram archive while emptying the target directories.
+
+   Only works for media associated with a specific profile, and that is returned
+   in chronological order: profile posts, profile stories, profile IGTV posts
+   and profile tagged posts.
+
+   By default, the information is stored in
+   ``~/.config/instaloader/latest-stamps.ini``, but you can specify an
+   alternative location.
+
+   .. versionadded:: 4.8
+
 .. option:: --post-filter filter, --only-if filter
 
    Expression that, if given, must evaluate to True for each post to be

--- a/docs/module/structures.rst
+++ b/docs/module/structures.rst
@@ -84,3 +84,9 @@ Loading and Saving
 .. autofunction:: get_json_structure
 
 .. autofunction:: save_structure_to_file
+
+LatestStamps
+""""""""""""
+
+.. autoclass:: LatestStamps
+   :no-show-inheritance:

--- a/instaloader/__init__.py
+++ b/instaloader/__init__.py
@@ -15,6 +15,7 @@ else:
 from .exceptions import *
 from .instaloader import Instaloader
 from .instaloadercontext import InstaloaderContext, RateController
+from .lateststamps import LatestStamps
 from .nodeiterator import NodeIterator, FrozenNodeIterator, resumable_iteration
 from .structures import (Hashtag, Highlight, Post, PostSidecarNode, PostComment, PostCommentAnswer, PostLocation,
                          Profile, Story, StoryItem, TopSearchResults, load_structure_from_file, save_structure_to_file,

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -177,7 +177,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
                                                      post_filter=post_filter)
                 elif re.match(r"^[A-Za-z0-9._]+$", target):
                     try:
-                        profile = instaloader.check_profile_id(target)
+                        profile = instaloader.check_profile_id(target, latest_stamps)
                         if instaloader.context.is_logged_in and profile.has_blocked_viewer:
                             if download_profile_pic or ((download_posts or download_tagged or download_igtv)
                                                         and not profile.is_private):
@@ -196,7 +196,8 @@ def _main(instaloader: Instaloader, targetlist: List[str],
                             instaloader.context.log("Trying again anonymously, helps in case you are just blocked.")
                             with instaloader.anonymous_copy() as anonymous_loader:
                                 with instaloader.context.error_catcher():
-                                    anonymous_retry_profiles.add(anonymous_loader.check_profile_id(target))
+                                    anonymous_retry_profiles.add(anonymous_loader.check_profile_id(target,
+                                                                                                   latest_stamps))
                                     instaloader.context.error("Warning: {} will be downloaded anonymously (\"{}\")."
                                                               .format(target, err))
                         else:

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 from . import (AbortDownloadException, BadCredentialsException, Instaloader, InstaloaderException,
                InvalidArgumentException, Post, Profile, ProfileNotExistsException, StoryItem,
                TwoFactorAuthRequiredException, __version__, load_structure_from_file)
-from .instaloader import get_default_session_filename
+from .instaloader import (get_default_session_filename, get_default_stamps_filename)
 from .instaloadercontext import default_user_agent
 from .lateststamps import LatestStamps
 
@@ -331,11 +331,10 @@ def main():
     g_cond.add_argument('-F', '--fast-update', action='store_true',
                         help='For each target, stop when encountering the first already-downloaded picture. This '
                              'flag is recommended when you use Instaloader to update your personal Instagram archive.')
-    g_cond.add_argument('--latest-stamps', metavar='STAMPSFILE',
-                        help='Path to a file to store the timestamps of latest media scraped for each profile. '
-                             'This allows updating your personal Instagram archive even if you delete the destination '
-                             'directories.')
-
+    g_cond.add_argument('--latest-stamps', nargs='?', metavar='STAMPSFILE', const=get_default_stamps_filename(),
+                        help='Store the timestamps of latest media scraped for each profile. This allows updating '
+                             'your personal Instagram archive even if you delete the destination directories. '
+                             'If STAMPSFILE is not provided, defaults to ' + get_default_stamps_filename())
     g_cond.add_argument('--post-filter', '--only-if', metavar='filter',
                         help='Expression that, if given, must evaluate to True for each post to be downloaded. Must be '
                              'a syntactically valid python expression. Variables are evaluated to '

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -27,18 +27,23 @@ from .structures import (Hashtag, Highlight, JsonExportable, Post, PostLocation,
                          load_structure_from_file, save_structure_to_file, PostSidecarNode, TitlePic)
 
 
-def get_default_session_filename(username: str) -> str:
-    """Returns default session filename for given username."""
-    sessionfilename = "session-{}".format(username)
+def _get_config_dir() -> str:
     if platform.system() == "Windows":
-        # on Windows, use %LOCALAPPDATA%\Instaloader\session-USERNAME
+        # on Windows, use %LOCALAPPDATA%\Instaloader
         localappdata = os.getenv("LOCALAPPDATA")
         if localappdata is not None:
-            return os.path.join(localappdata, "Instaloader", sessionfilename)
+            return os.path.join(localappdata, "Instaloader")
         # legacy fallback - store in temp dir if %LOCALAPPDATA% is not set
-        return os.path.join(tempfile.gettempdir(), ".instaloader-" + getpass.getuser(), sessionfilename)
-    # on Unix, use ~/.config/instaloader/session-USERNAME
-    return os.path.join(os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "instaloader", sessionfilename)
+        return os.path.join(tempfile.gettempdir(), ".instaloader-" + getpass.getuser())
+    # on Unix, use ~/.config/instaloader
+    return os.path.join(os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "instaloader")
+
+
+def get_default_session_filename(username: str) -> str:
+    """Returns default session filename for given username."""
+    configdir = _get_config_dir()
+    sessionfilename = "session-{}".format(username)
+    return os.path.join(configdir, sessionfilename)
 
 
 def get_legacy_session_filename(username: str) -> str:
@@ -46,6 +51,11 @@ def get_legacy_session_filename(username: str) -> str:
     dirname = tempfile.gettempdir() + "/" + ".instaloader-" + getpass.getuser()
     filename = dirname + "/" + "session-" + username
     return filename.lower()
+
+
+def get_default_stamps_filename() -> str:
+    configdir = _get_config_dir()
+    return os.path.join(configdir, "latest-stamps.ini")
 
 
 def format_string_contains_key(format_string: str, key: str) -> bool:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -499,6 +499,17 @@ class Instaloader:
             os.utime(filename, (datetime.now().timestamp(), date_object.timestamp()))
         self.context.log('')  # log output of _get_and_write_raw() does not produce \n
 
+    def download_profilepic_if_new(self, profile: Profile, latest_stamps: Optional[LatestStamps]) -> None:
+        if latest_stamps is None:
+            self.download_profilepic(profile)
+            return
+        profile_pic_basename = profile.profile_pic_url.split('/')[-1].split('?')[0]
+        saved_basename = latest_stamps.get_profile_pic(profile.username)
+        if saved_basename == profile_pic_basename:
+            return
+        self.download_profilepic(profile)
+        latest_stamps.set_profile_pic(profile.username, profile_pic_basename)
+
     def download_profilepic(self, profile: Profile) -> None:
         """Downloads and saves profile pic."""
         self.download_title_pic(profile.profile_pic_url, profile.username.lower(), 'profile_pic', profile)
@@ -1281,7 +1292,7 @@ class Instaloader:
                 # Download profile picture
                 if profile_pic:
                     with self.context.error_catcher('Download profile picture of {}'.format(profile_name)):
-                        self.download_profilepic(profile)
+                        self.download_profilepic_if_new(profile, latest_stamps)
 
                 # Save metadata as JSON if desired.
                 if self.save_metadata:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1190,6 +1190,14 @@ class Instaloader:
             return os.path.join(self.dirname_pattern.format(),
                                 '{0}_id'.format(profile_name.lower()))
 
+    def load_profile_id(self, profile_name: str) -> Optional[int]:
+        id_filename = self._get_id_filename(profile_name)
+        try:
+            with open(id_filename, 'rb') as id_file:
+                return int(id_file.read())
+        except (FileNotFoundError, ValueError):
+            return None
+
     def save_profile_id(self, profile: Profile):
         """
         Store ID of profile locally.
@@ -1216,10 +1224,8 @@ class Instaloader:
             profile = Profile.from_username(self.context, profile_name)
         except ProfileNotExistsException as err:
             profile_name_not_exists_err = err
-        id_filename = self._get_id_filename(profile_name)
-        try:
-            with open(id_filename, 'rb') as id_file:
-                profile_id = int(id_file.read())
+        profile_id = self.load_profile_id(profile_name)
+        if profile_id is not None:
             if (profile is None) or \
                     (profile_id != profile.userid):
                 if profile is not None:
@@ -1243,8 +1249,6 @@ class Instaloader:
                 return profile_from_id
             # profile exists and profile id matches saved id
             return profile
-        except (FileNotFoundError, ValueError):
-            pass
         if profile is not None:
             self.save_profile_id(profile)
             return profile

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -793,8 +793,9 @@ class Instaloader:
             if latest_stamps is not None:
                 # pylint:disable=cell-var-from-loop
                 last_scraped = latest_stamps.get_last_story_timestamp(name)
-                stories_to_download = takewhile(lambda s: s.date_local > last_scraped, stories_to_download)
-                scraped_timestamp = datetime.now()
+                stories_to_download = takewhile(lambda s: s.date_utc.replace(tzinfo=timezone.utc) > last_scraped,
+                                                stories_to_download)
+                scraped_timestamp = datetime.now().astimezone()
             for item in stories_to_download:
                 if storyitem_filter is not None and not storyitem_filter(item):
                     self.context.log("<{} skipped>".format(item), flush=True)
@@ -1369,8 +1370,9 @@ class Instaloader:
                     if latest_stamps is not None:
                         # pylint:disable=cell-var-from-loop
                         last_scraped = latest_stamps.get_last_post_timestamp(profile_name)
-                        posts_to_download = takewhile(lambda p: p.date_local > last_scraped, posts_to_download)
-                        scraped_timestamp = datetime.now()
+                        posts_to_download = takewhile(lambda p: p.date_utc.replace(tzinfo=timezone.utc) > last_scraped,
+                                                      posts_to_download)
+                        scraped_timestamp = datetime.now().astimezone()
                     self.posts_download_loop(posts_to_download, profile_name, fast_update, post_filter,
                                              total_count=profile.mediacount, owner_profile=profile)
                     if latest_stamps is not None:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -54,6 +54,12 @@ def get_legacy_session_filename(username: str) -> str:
 
 
 def get_default_stamps_filename() -> str:
+    """
+    Returns default filename for latest stamps database.
+
+    .. versionadded:: 4.8
+
+    """
     configdir = _get_config_dir()
     return os.path.join(configdir, "latest-stamps.ini")
 
@@ -510,6 +516,14 @@ class Instaloader:
         self.context.log('')  # log output of _get_and_write_raw() does not produce \n
 
     def download_profilepic_if_new(self, profile: Profile, latest_stamps: Optional[LatestStamps]) -> None:
+        """
+        Downloads and saves profile pic if it has not been downloaded before.
+
+        :param latest_stamps: Database with the last downloaded data. If not present,
+               the profile pic is downloaded unless it already exists
+
+        .. versionadded:: 4.8
+        """
         if latest_stamps is None:
             self.download_profilepic(profile)
             return
@@ -1175,7 +1189,10 @@ class Instaloader:
                         latest_stamps: Optional[LatestStamps] = None) -> None:
         """Download all posts where a profile is tagged.
 
-        .. versionadded:: 4.1"""
+        .. versionadded:: 4.1
+
+        .. versionchanged:: 4.8
+           Add `latest_stamps` parameter."""
         self.context.log("Retrieving tagged posts for profile {}.".format(profile.username))
         posts_to_download: Iterator[Post] = profile.get_tagged_posts()
         if latest_stamps is not None:
@@ -1196,7 +1213,10 @@ class Instaloader:
                       latest_stamps: Optional[LatestStamps] = None) -> None:
         """Download IGTV videos of a profile.
 
-        .. versionadded:: 4.3"""
+        .. versionadded:: 4.3
+
+        .. versionchanged:: 4.8
+           Add `latest_stamps` parameter."""
         self.context.log("Retrieving IGTV videos for profile {}.".format(profile.username))
         posts_to_download: Iterator[Post] = profile.get_igtv_posts()
         if latest_stamps is not None:
@@ -1220,6 +1240,11 @@ class Instaloader:
                                 '{0}_id'.format(profile_name.lower()))
 
     def load_profile_id(self, profile_name: str) -> Optional[int]:
+        """
+        Load ID of profile from profile directory.
+
+        .. versionadded:: 4.8
+        """
         id_filename = self._get_id_filename(profile_name)
         try:
             with open(id_filename, 'rb') as id_file:
@@ -1229,7 +1254,7 @@ class Instaloader:
 
     def save_profile_id(self, profile: Profile):
         """
-        Store ID of profile locally.
+        Store ID of profile on profile directory.
 
         .. versionadded:: 4.0.6
         """
@@ -1245,7 +1270,12 @@ class Instaloader:
         has changed and return current name of the profile, and store ID of profile.
 
         :param profile_name: Profile name
+        :param latest_stamps: Database of downloaded data. If present, IDs are retrieved from it,
+               otherwise from the target directory
         :return: Instance of current profile
+
+        .. versionchanged:: 4.8
+           Add `latest_stamps` parameter.
         """
         profile = None
         profile_name_not_exists_err = None

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -1,5 +1,5 @@
 import configparser
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -47,7 +47,7 @@ class LatestStamps:
         try:
             return datetime.strptime(self.data.get(section, key), self.ISO_FORMAT)
         except (configparser.Error, ValueError):
-            return datetime.min
+            return datetime.fromtimestamp(0, timezone.utc)
 
     def set_timestamp(self, section: str, key: str, timestamp: datetime):
         self.ensure_section(section)

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 class LatestStamps:
     POST_SECTION = 'post-timestamps'
+    STORY_SECTION = 'story-timestamps'
     PROFILE_PIC_SECTION = 'profile-pics'
 
     def __init__(self, latest_stamps_file):
@@ -19,16 +20,28 @@ class LatestStamps:
         if not self.data.has_section(section):
             self.data.add_section(section)
 
-    def get_last_post_timestamp(self, profile_name: str) -> datetime:
+    def get_timestamp(self, section: str, key: str) -> datetime:
         try:
-            return datetime.fromtimestamp(self.data.getint(self.POST_SECTION, profile_name))
+            return datetime.fromtimestamp(self.data.getint(section, key))
         except (configparser.Error, ValueError, OverflowError, OSError):
             return datetime.min
 
-    def set_last_post_timestamp(self, profile_name: str, timestamp: datetime):
-        self.ensure_section(self.POST_SECTION)
-        self.data.set(self.POST_SECTION, profile_name, str(int(timestamp.timestamp())))
+    def set_timestamp(self, section: str, key: str, timestamp: datetime):
+        self.ensure_section(section)
+        self.data.set(section, key, str(int(timestamp.timestamp())))
         self.save()
+
+    def get_last_post_timestamp(self, profile_name: str) -> datetime:
+        return self.get_timestamp(self.POST_SECTION, profile_name)
+
+    def set_last_post_timestamp(self, profile_name: str, timestamp: datetime):
+        self.set_timestamp(self.POST_SECTION, profile_name, timestamp)
+
+    def get_last_story_timestamp(self, profile_name: str) -> datetime:
+        return self.get_timestamp(self.STORY_SECTION, profile_name)
+
+    def set_last_story_timestamp(self, profile_name: str, timestamp: datetime):
+        self.set_timestamp(self.STORY_SECTION, profile_name, timestamp)
 
     def get_profile_pic(self, profile_name: str) -> str:
         try:

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -4,6 +4,13 @@ from typing import Optional
 
 
 class LatestStamps:
+    """LatestStamps class.
+
+    Convenience class for retrieving and storing data from the :option:`--latest-stamps` file.
+
+    :param latest_stamps_file: path to file.
+
+    .. versionadded:: 4.8"""
     PROFILE_ID = 'profile-id'
     PROFILE_PIC = 'profile-pic'
     POST_TIMESTAMP = 'post-timestamp'

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 class LatestStamps:
     POST_SECTION = 'post-timestamps'
+    PROFILE_PIC_SECTION = 'profile-pics'
 
     def __init__(self, latest_stamps_file):
         self.file = latest_stamps_file
@@ -14,6 +15,10 @@ class LatestStamps:
         with open(self.file, 'w') as f:
             self.data.write(f)
 
+    def ensure_section(self, section: str):
+        if not self.data.has_section(section):
+            self.data.add_section(section)
+
     def get_last_post_timestamp(self, profile_name: str) -> datetime:
         try:
             return datetime.fromtimestamp(self.data.getint(self.POST_SECTION, profile_name))
@@ -21,8 +26,17 @@ class LatestStamps:
             return datetime.min
 
     def set_last_post_timestamp(self, profile_name: str, timestamp: datetime):
-        if not self.data.has_section(self.POST_SECTION):
-            self.data.add_section(self.POST_SECTION)
+        self.ensure_section(self.POST_SECTION)
         self.data.set(self.POST_SECTION, profile_name, str(int(timestamp.timestamp())))
         self.save()
 
+    def get_profile_pic(self, profile_name: str) -> str:
+        try:
+            return self.data.get(self.PROFILE_PIC_SECTION, profile_name)
+        except configparser.Error:
+            return ""
+
+    def set_profile_pic(self, profile_name: str, profile_pic: str):
+        self.ensure_section(self.PROFILE_PIC_SECTION)
+        self.data.set(self.PROFILE_PIC_SECTION, profile_name, profile_pic)
+        self.save()

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -7,6 +7,7 @@ class LatestStamps:
     PROFILE_ID = 'profile-id'
     PROFILE_PIC = 'profile-pic'
     POST_TIMESTAMP = 'post-timestamp'
+    IGTV_TIMESTAMP = 'igtv-timestamp'
     STORY_TIMESTAMP = 'story-timestamp'
     ISO_FORMAT = '%Y-%m-%dT%H:%M:%S.%f%z'
 
@@ -36,7 +37,8 @@ class LatestStamps:
 
     def rename_profile(self, old_profile: str, new_profile: str):
         self.ensure_section(new_profile)
-        for option in [self.PROFILE_ID, self.PROFILE_PIC, self.POST_TIMESTAMP, self.STORY_TIMESTAMP]:
+        for option in [self.PROFILE_ID, self.PROFILE_PIC, self.POST_TIMESTAMP,
+                       self.IGTV_TIMESTAMP, self.STORY_TIMESTAMP]:
             if self.data.has_option(old_profile, option):
                 value = self.data.get(old_profile, option)
                 self.data.set(new_profile, option, value)
@@ -59,6 +61,12 @@ class LatestStamps:
 
     def set_last_post_timestamp(self, profile_name: str, timestamp: datetime):
         self.set_timestamp(profile_name, self.POST_TIMESTAMP, timestamp)
+
+    def get_last_igtv_timestamp(self, profile_name: str) -> datetime:
+        return self.get_timestamp(profile_name, self.IGTV_TIMESTAMP)
+
+    def set_last_igtv_timestamp(self, profile_name: str, timestamp: datetime):
+        self.set_timestamp(profile_name, self.IGTV_TIMESTAMP, timestamp)
 
     def get_last_story_timestamp(self, profile_name: str) -> datetime:
         return self.get_timestamp(profile_name, self.STORY_TIMESTAMP)

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -1,8 +1,10 @@
 import configparser
 from datetime import datetime
+from typing import Optional
 
 
 class LatestStamps:
+    ID_SECTION = 'profile-ids'
     POST_SECTION = 'post-timestamps'
     STORY_SECTION = 'story-timestamps'
     PROFILE_PIC_SECTION = 'profile-pics'
@@ -19,6 +21,25 @@ class LatestStamps:
     def ensure_section(self, section: str):
         if not self.data.has_section(section):
             self.data.add_section(section)
+
+    def get_profile_id(self, profile_name: str) -> Optional[int]:
+        try:
+            return self.data.getint(self.ID_SECTION, profile_name)
+        except (configparser.Error, ValueError):
+            return None
+
+    def save_profile_id(self, profile_name: str, profile_id: int):
+        self.ensure_section(self.ID_SECTION)
+        self.data.set(self.ID_SECTION, profile_name, str(profile_id))
+        self.save()
+
+    def rename_profile(self, old_profile: str, new_profile: str):
+        for section in [self.ID_SECTION, self.POST_SECTION, self.STORY_SECTION, self.PROFILE_PIC_SECTION]:
+            if self.data.has_option(section, old_profile):
+                value = self.data.get(section, old_profile)
+                self.data.set(section, new_profile, value)
+                self.data.remove_option(section, old_profile)
+        self.save()
 
     def get_timestamp(self, section: str, key: str) -> datetime:
         try:

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -24,77 +24,90 @@ class LatestStamps:
         self.data = configparser.ConfigParser()
         self.data.read(latest_stamps_file)
 
-    def save(self):
+    def _save(self):
         with open(self.file, 'w') as f:
             self.data.write(f)
 
-    def ensure_section(self, section: str):
+    def _ensure_section(self, section: str):
         if not self.data.has_section(section):
             self.data.add_section(section)
 
     def get_profile_id(self, profile_name: str) -> Optional[int]:
+        """Returns stored ID of profile."""
         try:
             return self.data.getint(profile_name, self.PROFILE_ID)
         except (configparser.Error, ValueError):
             return None
 
     def save_profile_id(self, profile_name: str, profile_id: int):
-        self.ensure_section(profile_name)
+        """Stores ID of profile."""
+        self._ensure_section(profile_name)
         self.data.set(profile_name, self.PROFILE_ID, str(profile_id))
-        self.save()
+        self._save()
 
     def rename_profile(self, old_profile: str, new_profile: str):
-        self.ensure_section(new_profile)
+        """Renames a profile."""
+        self._ensure_section(new_profile)
         for option in [self.PROFILE_ID, self.PROFILE_PIC, self.POST_TIMESTAMP,
                        self.TAGGED_TIMESTAMP, self.IGTV_TIMESTAMP, self.STORY_TIMESTAMP]:
             if self.data.has_option(old_profile, option):
                 value = self.data.get(old_profile, option)
                 self.data.set(new_profile, option, value)
         self.data.remove_section(old_profile)
-        self.save()
+        self._save()
 
-    def get_timestamp(self, section: str, key: str) -> datetime:
+    def _get_timestamp(self, section: str, key: str) -> datetime:
         try:
             return datetime.strptime(self.data.get(section, key), self.ISO_FORMAT)
         except (configparser.Error, ValueError):
             return datetime.fromtimestamp(0, timezone.utc)
 
-    def set_timestamp(self, section: str, key: str, timestamp: datetime):
-        self.ensure_section(section)
+    def _set_timestamp(self, section: str, key: str, timestamp: datetime):
+        self._ensure_section(section)
         self.data.set(section, key, timestamp.strftime(self.ISO_FORMAT))
-        self.save()
+        self._save()
 
     def get_last_post_timestamp(self, profile_name: str) -> datetime:
-        return self.get_timestamp(profile_name, self.POST_TIMESTAMP)
+        """Returns timestamp of last download of a profile's posts."""
+        return self._get_timestamp(profile_name, self.POST_TIMESTAMP)
 
     def set_last_post_timestamp(self, profile_name: str, timestamp: datetime):
-        self.set_timestamp(profile_name, self.POST_TIMESTAMP, timestamp)
+        """Sets timestamp of last download of a profile's posts."""
+        self._set_timestamp(profile_name, self.POST_TIMESTAMP, timestamp)
 
     def get_last_tagged_timestamp(self, profile_name: str) -> datetime:
-        return self.get_timestamp(profile_name, self.TAGGED_TIMESTAMP)
+        """Returns timestamp of last download of a profile's tagged posts."""
+        return self._get_timestamp(profile_name, self.TAGGED_TIMESTAMP)
 
     def set_last_tagged_timestamp(self, profile_name: str, timestamp: datetime):
-        self.set_timestamp(profile_name, self.TAGGED_TIMESTAMP, timestamp)
+        """Sets timestamp of last download of a profile's tagged posts."""
+        self._set_timestamp(profile_name, self.TAGGED_TIMESTAMP, timestamp)
 
     def get_last_igtv_timestamp(self, profile_name: str) -> datetime:
-        return self.get_timestamp(profile_name, self.IGTV_TIMESTAMP)
+        """Returns timestamp of last download of a profile's igtv posts."""
+        return self._get_timestamp(profile_name, self.IGTV_TIMESTAMP)
 
     def set_last_igtv_timestamp(self, profile_name: str, timestamp: datetime):
-        self.set_timestamp(profile_name, self.IGTV_TIMESTAMP, timestamp)
+        """Sets timestamp of last download of a profile's igtv posts."""
+        self._set_timestamp(profile_name, self.IGTV_TIMESTAMP, timestamp)
 
     def get_last_story_timestamp(self, profile_name: str) -> datetime:
-        return self.get_timestamp(profile_name, self.STORY_TIMESTAMP)
+        """Returns timestamp of last download of a profile's stories."""
+        return self._get_timestamp(profile_name, self.STORY_TIMESTAMP)
 
     def set_last_story_timestamp(self, profile_name: str, timestamp: datetime):
-        self.set_timestamp(profile_name, self.STORY_TIMESTAMP, timestamp)
+        """Sets timestamp of last download of a profile's stories."""
+        self._set_timestamp(profile_name, self.STORY_TIMESTAMP, timestamp)
 
     def get_profile_pic(self, profile_name: str) -> str:
+        """Returns filename of profile's last downloaded profile pic."""
         try:
             return self.data.get(profile_name, self.PROFILE_PIC)
         except configparser.Error:
             return ""
 
     def set_profile_pic(self, profile_name: str, profile_pic: str):
-        self.ensure_section(profile_name)
+        """Sets filename of profile's last downloaded profile pic."""
+        self._ensure_section(profile_name)
         self.data.set(profile_name, self.PROFILE_PIC, profile_pic)
-        self.save()
+        self._save()

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -7,6 +7,7 @@ class LatestStamps:
     PROFILE_ID = 'profile-id'
     PROFILE_PIC = 'profile-pic'
     POST_TIMESTAMP = 'post-timestamp'
+    TAGGED_TIMESTAMP = 'tagged-timestamp'
     IGTV_TIMESTAMP = 'igtv-timestamp'
     STORY_TIMESTAMP = 'story-timestamp'
     ISO_FORMAT = '%Y-%m-%dT%H:%M:%S.%f%z'
@@ -38,7 +39,7 @@ class LatestStamps:
     def rename_profile(self, old_profile: str, new_profile: str):
         self.ensure_section(new_profile)
         for option in [self.PROFILE_ID, self.PROFILE_PIC, self.POST_TIMESTAMP,
-                       self.IGTV_TIMESTAMP, self.STORY_TIMESTAMP]:
+                       self.TAGGED_TIMESTAMP, self.IGTV_TIMESTAMP, self.STORY_TIMESTAMP]:
             if self.data.has_option(old_profile, option):
                 value = self.data.get(old_profile, option)
                 self.data.set(new_profile, option, value)
@@ -61,6 +62,12 @@ class LatestStamps:
 
     def set_last_post_timestamp(self, profile_name: str, timestamp: datetime):
         self.set_timestamp(profile_name, self.POST_TIMESTAMP, timestamp)
+
+    def get_last_tagged_timestamp(self, profile_name: str) -> datetime:
+        return self.get_timestamp(profile_name, self.TAGGED_TIMESTAMP)
+
+    def set_last_tagged_timestamp(self, profile_name: str, timestamp: datetime):
+        self.set_timestamp(profile_name, self.TAGGED_TIMESTAMP, timestamp)
 
     def get_last_igtv_timestamp(self, profile_name: str) -> datetime:
         return self.get_timestamp(profile_name, self.IGTV_TIMESTAMP)

--- a/instaloader/lateststamps.py
+++ b/instaloader/lateststamps.py
@@ -1,0 +1,28 @@
+import configparser
+from datetime import datetime
+
+
+class LatestStamps:
+    POST_SECTION = 'post-timestamps'
+
+    def __init__(self, latest_stamps_file):
+        self.file = latest_stamps_file
+        self.data = configparser.ConfigParser()
+        self.data.read(latest_stamps_file)
+
+    def save(self):
+        with open(self.file, 'w') as f:
+            self.data.write(f)
+
+    def get_last_post_timestamp(self, profile_name: str) -> datetime:
+        try:
+            return datetime.fromtimestamp(self.data.getint(self.POST_SECTION, profile_name))
+        except (configparser.Error, ValueError, OverflowError, OSError):
+            return datetime.min
+
+    def set_last_post_timestamp(self, profile_name: str, timestamp: datetime):
+        if not self.data.has_section(self.POST_SECTION):
+            self.data.add_section(self.POST_SECTION)
+        self.data.set(self.POST_SECTION, profile_name, str(int(timestamp.timestamp())))
+        self.save()
+


### PR DESCRIPTION
See #1122 for details.

This adds an option `--latest-stamps` pointing to a file that stores the timestamp each profile was last downloaded. On the next run, only posts newer that that timestamp are downloaded.

Currently works for posts and stories. I could try to enhance it to support tagged posts, hashtags, etc. As noted on #1122, some feeds are not chronological. I suppose a solution like in #666 could be used. Storing ids of everything downloaded would probably take too much space.

Profile IDs are also stored in the stamps file, and there's also a check to avoid redownloading profile pics. In this case, since there isn't a reliable timestamp, the file name is used.

BTW, This feature was inspired by a similar functionality in https://github.com/arc298/instagram-scraper/, and the file format is similar (but not exactly the same).

**Is it just a proof of concept?** Yes, but I'm willing to make it more complete
**Is the documentation updated (if appropriate)?** Not yet
**Do you consider it ready to be merged or is it a draft?** It's still a draft
**Can we help you at some point?** Certainly, reviewing what's been done and suggesting ways to implement with the parts not yet written
