### PR TITLE
update documentation for --count option

### DIFF
--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -164,8 +164,8 @@ Which Posts to Download
 
 .. option:: --count COUNT, -c
 
-   Do not attempt to download more than COUNT posts.  Applies only to
-   ``#hashtag``, ``%location id``, and ``:feed``.
+   Do not attempt to download more than COUNT posts.  Applies to
+   ``#hashtag``, ``%location_id``, ``:feed``, and ``:saved``.
 
 
 Login (Download Private Profiles)

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -335,7 +335,7 @@ def main():
 
     g_cond.add_argument('-c', '--count',
                         help='Do not attempt to download more than COUNT posts. '
-                             'Applies only to #hashtag and :feed.')
+                             'Applies to #hashtag, %%location_id, :feed, and :saved.')
 
     g_login = parser.add_argument_group('Login (Download Private Profiles)',
                                         'Instaloader can login to Instagram. This allows downloading private profiles. '


### PR DESCRIPTION
## Motivation

The documentation for `--count` was out of date in the changed files. It has been corrected to note that `--count` works for the four options `#hashtag`, `%location_id`, `:feed`, and `:saved` as evidenced in `_main` within `instaloader/__main__.py`

I have tested my changes and this pull request seems ready.