### PR TITLE
Fix and Update has_public_story Functionality

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -591,7 +591,7 @@ class Profile:
         assert 'username' in node
         self._context = context
         self._has_public_story = None  # type: Optional[bool]
-        self._has_public_story_anon = None  # type: Optional[bool]        
+        self._has_public_story_anon = None  # type: Optional[bool]
         self._node = node
         self._has_full_metadata = False
         self._iphone_struct_ = None
@@ -796,11 +796,11 @@ class Profile:
             self._obtain_metadata()
             # query rate is limited:
             data = self._context.graphql_query('9ca88e465c3f866a76f7adee3871bdd8',
-                                                    {'user_id': self.userid, 'include_chaining': False,
-                                                    'include_reel': False, 'include_suggested_users': False,
-                                                    'include_logged_out_extras': True,
-                                                    'include_highlight_reels': False},
-                                                    'https://www.instagram.com/{}/'.format(self.username))
+                                               {'user_id': self.userid, 'include_chaining': False,
+                                                'include_reel': False, 'include_suggested_users': False,
+                                                'include_logged_out_extras': True,
+                                                'include_highlight_reels': False},
+                                               'https://www.instagram.com/{}/'.format(self.username))
             self._has_public_story = data['data']['user']['has_public_story']
         assert self._has_public_story is not None
         return self._has_public_story

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -591,7 +591,6 @@ class Profile:
         assert 'username' in node
         self._context = context
         self._has_public_story = None  # type: Optional[bool]
-        self._has_public_story_anon = None  # type: Optional[bool]
         self._node = node
         self._has_full_metadata = False
         self._iphone_struct_ = None
@@ -794,7 +793,7 @@ class Profile:
     def has_public_story(self) -> bool:
         if not self._has_public_story:
             self._obtain_metadata()
-            # query rate is limited:
+            # query rate might be limited:
             data = self._context.graphql_query('9ca88e465c3f866a76f7adee3871bdd8',
                                                {'user_id': self.userid, 'include_chaining': False,
                                                 'include_reel': False, 'include_suggested_users': False,
@@ -804,22 +803,6 @@ class Profile:
             self._has_public_story = data['data']['user']['has_public_story']
         assert self._has_public_story is not None
         return self._has_public_story
-
-    @property
-    def has_public_story_anon(self) -> bool:
-        if not self._has_public_story_anon:
-            self._obtain_metadata()
-            # query not rate limited if invoked anonymously:
-            with self._context.anonymous_copy() as anonymous_context:
-                data = anonymous_context.graphql_query('9ca88e465c3f866a76f7adee3871bdd8',
-                                                       {'user_id': self.userid, 'include_chaining': False,
-                                                        'include_reel': False, 'include_suggested_users': False,
-                                                        'include_logged_out_extras': True,
-                                                        'include_highlight_reels': False},
-                                                       'https://www.instagram.com/{}/'.format(self.username))
-            self._has_public_story_anon = data['data']['user']['has_public_story']
-        assert self._has_public_story_anon is not None
-        return self._has_public_story_anon
 
     @property
     def has_viewable_story(self) -> bool:


### PR DESCRIPTION
If you perform too many queries from a certain IP `has_public_story()` no longer works.


Using this simple example:

``` python
import instaloader

L = instaloader.Instaloader()
L.load_session_from_file('...')

profile = instaloader.Post.from_shortcode(L.context, 'bmw')

print(profile.has_public_story)
print(profile.has_viewable_story)
```

``` bash
HTTP redirect from https://www.instagram.com/graphql/query to https://www.instagram.com/accounts/login/
Traceback (most recent call last):
  File "e:/instaloader/TODO.py", line 9, in <module>
    print(profile.has_public_story)
  File "e:\instaloader\instaloader\structures.py", line 803, in has_public_story
  File "e:\instaloader\instaloader\instaloadercontext.py", line 430, in graphql_query
    session=tmpsession)
  File "e:\instaloader\instaloader\instaloadercontext.py", line 335, in get_json
    raise LoginRequiredException("Redirected to login page. Use --login.")
instaloader.exceptions.LoginRequiredException: Redirected to login page. Use --login.
```

This occurs because the query is invoked anonymously.

``` python
# query not rate limited if invoked anonymously:
with self._context.anonymous_copy() as anonymous_context:
```

Fix: Give users the option to call the query both anonymously and not anonymously with the following functions

* ```has_public_story()```
* ```has_public_story_anon()```