### PR TITLE
Create user session using cookies exported using the EditThisCookie addon (Chrome and others)

### DIFF
--- a/docs/codesnippets/616_import_cookies_from_EditThisCookie_addon.py
+++ b/docs/codesnippets/616_import_cookies_from_EditThisCookie_addon.py
@@ -1,0 +1,59 @@
+# This will automatically import cookies and create a session file
+# Works on all browsers that support EditThisCookie extension (http://www.editthiscookie.com/)
+#
+# Instructions:
+#     1. Install EditThisCookie extension on your supported browser
+#     2. Login to your Instagram account on that browser
+#     3. Export the cookies using the EditThisCookie extension (will copy them to the clipboard)
+#     4. Paste the exported cookies to a file (cookies.txt is the default filename)
+#     5. Use this script to create a valid session file
+
+from argparse import ArgumentParser
+from glob import glob
+from os.path import expanduser
+from platform import system
+import json
+
+try:
+    from instaloader import ConnectionException, Instaloader
+except ModuleNotFoundError:
+    raise SystemExit("Instaloader not found.\n  pip install [--user] instaloader")
+
+
+def get_cookiefile():
+    default_cookiefile = "cookies.txt"
+    cookiefiles = glob(expanduser(default_cookiefile))
+    if not cookiefiles:
+        raise SystemExit("No exported cookies file found. Use -c COOKIEFILE.")
+    return cookiefiles[0]
+
+
+def import_session(cookiefile, sessionfile):
+    print("Using cookies from {}.".format(cookiefile))
+
+    with open(cookiefile, 'r') as f:
+        data = json.load(f)
+
+    cookie_data = {}
+    for x in data:
+        cookie_data[str(x["name"])] = str(x["value"])    
+        
+    instaloader = Instaloader(max_connection_attempts=1)
+    instaloader.context._session.cookies.update(cookie_data)
+    username = instaloader.test_login()
+    if not username:
+        raise SystemExit("Not logged in. Have you correctly exported and created your cookies file?")
+    print("Imported session cookie for {}.".format(username))
+    instaloader.context.username = username
+    instaloader.save_session_to_file(sessionfile)
+
+
+if __name__ == "__main__":
+    p = ArgumentParser()
+    p.add_argument("-c", "--cookiefile")
+    p.add_argument("-f", "--sessionfile")
+    args = p.parse_args()
+    try:
+        import_session(args.cookiefile or get_cookiefile(), args.sessionfile)
+    except (ConnectionException, OperationalError) as e:
+        raise SystemExit("Cookie import failed: {}".format(e))


### PR DESCRIPTION

<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
This should help while a fix to #1150 is implemented. It's a modified version of 615_import_firefox_session.py that will create a user session file from cookies dumped in JSON format. I personally use [EditThisCookie ](http://www.editthiscookie.com/)on Chrome.

Since I don't use Firefox and I also use instaloader on a Linux headless server  the 615_import_firefox_session.py script didn't fix my login issue reported in #1150 . What I do now is log in to my Instagram account on my usual Chrome browser, export the cookies in JSON format (I use [EditThisCookie](http://www.editthiscookie.com/) but there's many addons for this) and I just have to paste that into a "cookies.txt" file on a remote ssh connection to the Linux server.
