### PR TITLE
fixes #1150 and #1191

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -210,8 +210,8 @@ class InstaloaderContext:
         # Override default timeout behavior.
         # Need to silence mypy bug for this. See: https://github.com/python/mypy/issues/2427
         session.request = partial(session.request, timeout=self.request_timeout) # type: ignore
-        session.get('https://www.instagram.com/web/__mid/')
-        csrf_token = session.cookies.get_dict()['csrftoken']
+        res = session.get('https://www.instagram.com/accounts/login/')
+        csrf_token = re.findall(r"csrf_token\":\"(.*?)\"", res.text)[0]
         session.headers.update({'X-CSRFToken': csrf_token})
         # Not using self.get_json() here, because we need to access csrftoken cookie
         self.do_sleep()

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -210,8 +210,8 @@ class InstaloaderContext:
         # Override default timeout behavior.
         # Need to silence mypy bug for this. See: https://github.com/python/mypy/issues/2427
         session.request = partial(session.request, timeout=self.request_timeout) # type: ignore
-        res = session.get('https://www.instagram.com/accounts/login/')
-        csrf_token = re.findall(r"csrf_token\":\"(.*?)\"", res.text)[0]
+        csrf_json = self.get_json('accounts/login/', {}, session=session)
+        csrf_token = csrf_json['config']['csrf_token']
         session.headers.update({'X-CSRFToken': csrf_token})
         # Not using self.get_json() here, because we need to access csrftoken cookie
         self.do_sleep()


### PR DESCRIPTION
taking csrf token from the instagram login page as it is empty using the old url

this should fix JSONDecodeError when trying to log in (at least in Europe). The error was described in #1150 as well as #1191 