### PR TITLE
Fix interruped downloads with --latest-stamps (#1206)

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1203,14 +1203,14 @@ class Instaloader:
         if latest_stamps is not None:
             last_scraped = latest_stamps.get_last_tagged_timestamp(profile.username)
             posts_takewhile = lambda p: p.date_utc.replace(tzinfo=timezone.utc) > last_scraped
-            scraped_timestamp = datetime.now().astimezone()
-        self.posts_download_loop(profile.get_tagged_posts(),
+        tagged_posts = profile.get_tagged_posts()
+        self.posts_download_loop(tagged_posts,
                                  target if target
                                  else (Path(_PostPathFormatter.sanitize_path(profile.username)) /
                                        _PostPathFormatter.sanitize_path(':tagged')),
                                  fast_update, post_filter, takewhile=posts_takewhile)
-        if latest_stamps is not None:
-            latest_stamps.set_last_tagged_timestamp(profile.username, scraped_timestamp)
+        if latest_stamps is not None and tagged_posts.first_item_timestamp is not None:
+            latest_stamps.set_last_tagged_timestamp(profile.username, tagged_posts.first_item_timestamp.astimezone())
 
     def download_igtv(self, profile: Profile, fast_update: bool = False,
                       post_filter: Optional[Callable[[Post], bool]] = None,
@@ -1226,11 +1226,11 @@ class Instaloader:
         if latest_stamps is not None:
             last_scraped = latest_stamps.get_last_igtv_timestamp(profile.username)
             posts_takewhile = lambda p: p.date_utc.replace(tzinfo=timezone.utc) > last_scraped
-            scraped_timestamp = datetime.now().astimezone()
-        self.posts_download_loop(profile.get_igtv_posts(), profile.username, fast_update, post_filter,
+        igtv_posts = profile.get_igtv_posts()
+        self.posts_download_loop(igtv_posts, profile.username, fast_update, post_filter,
                                  total_count=profile.igtvcount, owner_profile=profile, takewhile=posts_takewhile)
-        if latest_stamps is not None:
-            latest_stamps.set_last_igtv_timestamp(profile.username, scraped_timestamp)
+        if latest_stamps is not None and igtv_posts.first_item_timestamp is not None:
+            latest_stamps.set_last_igtv_timestamp(profile.username, igtv_posts.first_item_timestamp.astimezone())
 
     def _get_id_filename(self, profile_name: str) -> str:
         if ((format_string_contains_key(self.dirname_pattern, 'profile') or
@@ -1424,12 +1424,13 @@ class Instaloader:
                         # pylint:disable=cell-var-from-loop
                         last_scraped = latest_stamps.get_last_post_timestamp(profile_name)
                         posts_takewhile = lambda p: p.date_utc.replace(tzinfo=timezone.utc) > last_scraped
-                        scraped_timestamp = datetime.now().astimezone()
-                    self.posts_download_loop(profile.get_posts(), profile_name, fast_update, post_filter,
+                    posts_to_download = profile.get_posts()
+                    self.posts_download_loop(posts_to_download, profile_name, fast_update, post_filter,
                                              total_count=profile.mediacount, owner_profile=profile,
                                              takewhile=posts_takewhile)
-                    if latest_stamps is not None:
-                        latest_stamps.set_last_post_timestamp(profile_name, scraped_timestamp)
+                    if latest_stamps is not None and posts_to_download.first_item_timestamp is not None:
+                        latest_stamps.set_last_post_timestamp(profile_name,
+                                                              posts_to_download.first_item_timestamp.astimezone())
 
         if stories and profiles:
             with self.context.error_catcher("Download stories"):

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1209,8 +1209,8 @@ class Instaloader:
                                  else (Path(_PostPathFormatter.sanitize_path(profile.username)) /
                                        _PostPathFormatter.sanitize_path(':tagged')),
                                  fast_update, post_filter, takewhile=posts_takewhile)
-        if latest_stamps is not None and tagged_posts.first_item_timestamp is not None:
-            latest_stamps.set_last_tagged_timestamp(profile.username, tagged_posts.first_item_timestamp.astimezone())
+        if latest_stamps is not None and tagged_posts.first_item is not None:
+            latest_stamps.set_last_tagged_timestamp(profile.username, tagged_posts.first_item.date_local.astimezone())
 
     def download_igtv(self, profile: Profile, fast_update: bool = False,
                       post_filter: Optional[Callable[[Post], bool]] = None,
@@ -1229,8 +1229,8 @@ class Instaloader:
         igtv_posts = profile.get_igtv_posts()
         self.posts_download_loop(igtv_posts, profile.username, fast_update, post_filter,
                                  total_count=profile.igtvcount, owner_profile=profile, takewhile=posts_takewhile)
-        if latest_stamps is not None and igtv_posts.first_item_timestamp is not None:
-            latest_stamps.set_last_igtv_timestamp(profile.username, igtv_posts.first_item_timestamp.astimezone())
+        if latest_stamps is not None and igtv_posts.first_item is not None:
+            latest_stamps.set_last_igtv_timestamp(profile.username, igtv_posts.first_item.date_local.astimezone())
 
     def _get_id_filename(self, profile_name: str) -> str:
         if ((format_string_contains_key(self.dirname_pattern, 'profile') or
@@ -1428,9 +1428,9 @@ class Instaloader:
                     self.posts_download_loop(posts_to_download, profile_name, fast_update, post_filter,
                                              total_count=profile.mediacount, owner_profile=profile,
                                              takewhile=posts_takewhile)
-                    if latest_stamps is not None and posts_to_download.first_item_timestamp is not None:
+                    if latest_stamps is not None and posts_to_download.first_item is not None:
                         latest_stamps.set_last_post_timestamp(profile_name,
-                                                              posts_to_download.first_item_timestamp.astimezone())
+                                                              posts_to_download.first_item.date_local.astimezone())
 
         if stories and profiles:
             with self.context.error_catcher("Download stories"):

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -129,7 +129,8 @@ class NodeIterator(Iterator[T]):
                 raise
             item = self._node_wrapper(node)
             if self._first_item_timestamp is None and hasattr(item, 'date_utc'):
-                self._first_item_timestamp = item.date_utc.replace(tzinfo=timezone.utc)
+                # Suppress MyPy error, it is checked that T has date_utc in the previous line
+                self._first_item_timestamp = item.date_utc.replace(tzinfo=timezone.utc) # type: ignore
             return item
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import os
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from lzma import LZMAError
 from typing import Any, Callable, Dict, Iterable, Iterator, NamedTuple, Optional, Tuple, TypeVar
 
@@ -17,7 +17,8 @@ FrozenNodeIterator = NamedTuple('FrozenNodeIterator',
                                  ('context_username', Optional[str]),
                                  ('total_index', int),
                                  ('best_before', Optional[float]),
-                                 ('remaining_data', Optional[Dict])])
+                                 ('remaining_data', Optional[Dict]),
+                                 ('first_item_timestamp', Optional[str])])
 FrozenNodeIterator.query_hash.__doc__ = """The GraphQL ``query_hash`` parameter."""
 FrozenNodeIterator.query_variables.__doc__ = """The GraphQL ``query_variables`` parameter."""
 FrozenNodeIterator.query_referer.__doc__ = """The HTTP referer used for the GraphQL query."""
@@ -26,7 +27,7 @@ FrozenNodeIterator.total_index.__doc__ = """Number of items that have already be
 FrozenNodeIterator.best_before.__doc__ = """Date when parts of the stored nodes might have expired."""
 FrozenNodeIterator.remaining_data.__doc__ = \
     """The already-retrieved, yet-unprocessed ``edges`` and the ``page_info`` at time of freezing."""
-
+FrozenNodeIterator.first_item_timestamp.__doc__ = """Timestamp (UTC) of first item, if an item has been produced."""
 
 T = TypeVar('T')
 
@@ -89,6 +90,7 @@ class NodeIterator(Iterator[T]):
             self._best_before = datetime.now() + NodeIterator._shelf_life
         else:
             self._data = self._query()
+        self._first_item_timestamp: Optional[datetime] = None
 
     def _query(self, after: Optional[str] = None) -> Dict:
         pagination_variables = {'first': NodeIterator._graphql_page_length}  # type: Dict[str, Any]
@@ -125,7 +127,10 @@ class NodeIterator(Iterator[T]):
             except KeyboardInterrupt:
                 self._page_index, self._total_index = page_index, total_index
                 raise
-            return self._node_wrapper(node)
+            item = self._node_wrapper(node)
+            if self._first_item_timestamp is None:
+                self._first_item_timestamp = item.date_utc.replace(tzinfo=timezone.utc)
+            return item
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])
             page_index, data = self._page_index, self._data
@@ -157,6 +162,11 @@ class NodeIterator(Iterator[T]):
         ).encode())
         return base64.urlsafe_b64encode(magic_hash.digest()).decode()
 
+    @property
+    def first_item_timestamp(self) -> Optional[datetime]:
+        """If this iterator has produced any items, returns the timestamp of that item, in UTC."""
+        return self._first_item_timestamp
+
     def freeze(self) -> FrozenNodeIterator:
         """Freeze the iterator for later resuming."""
         remaining_data = None
@@ -171,6 +181,8 @@ class NodeIterator(Iterator[T]):
             total_index=max(self.total_index - 1, 0),
             best_before=self._best_before.timestamp() if self._best_before else None,
             remaining_data=remaining_data,
+            first_item_timestamp=self._first_item_timestamp.timestamp() if self._first_item_timestamp is not None \
+                else None,
         )
 
     def thaw(self, frozen: FrozenNodeIterator) -> None:
@@ -197,6 +209,8 @@ class NodeIterator(Iterator[T]):
         self._total_index = frozen.total_index
         self._best_before = datetime.fromtimestamp(frozen.best_before)
         self._data = frozen.remaining_data
+        if frozen.first_item_timestamp is not None:
+            self._first_item_timestamp = datetime.fromtimestamp(frozen.first_item_timestamp, timezone.utc)
 
 
 @contextmanager

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -18,7 +18,7 @@ FrozenNodeIterator = NamedTuple('FrozenNodeIterator',
                                  ('total_index', int),
                                  ('best_before', Optional[float]),
                                  ('remaining_data', Optional[Dict]),
-                                 ('first_item_timestamp', Optional[str])])
+                                 ('first_item_timestamp', Optional[float])])
 FrozenNodeIterator.query_hash.__doc__ = """The GraphQL ``query_hash`` parameter."""
 FrozenNodeIterator.query_variables.__doc__ = """The GraphQL ``query_variables`` parameter."""
 FrozenNodeIterator.query_referer.__doc__ = """The HTTP referer used for the GraphQL query."""
@@ -128,7 +128,7 @@ class NodeIterator(Iterator[T]):
                 self._page_index, self._total_index = page_index, total_index
                 raise
             item = self._node_wrapper(node)
-            if self._first_item_timestamp is None:
+            if self._first_item_timestamp is None and hasattr(item, 'date_utc'):
                 self._first_item_timestamp = item.date_utc.replace(tzinfo=timezone.utc)
             return item
         if self._data['page_info']['has_next_page']:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1643,6 +1643,8 @@ def load_structure(context: InstaloaderContext, json_structure: dict) -> JsonExp
         elif node_type == "Hashtag":
             return Hashtag(context, json_structure['node'])
         elif node_type == "FrozenNodeIterator":
+            if not 'first_node' in json_structure['node']:
+                json_structure['node']['first_node'] = None
             return FrozenNodeIterator(**json_structure['node'])
     elif 'shortcode' in json_structure:
         # Post JSON created with Instaloader v3


### PR DESCRIPTION
Fixes #1206 

The timestamp of the most recent post is cached in NodeIterator (and saved to the disk), and this timestamp is stored, instead of the timestamp instaloader was run.

This way, even in later resuming runs the timestamp stored is the same that would have been stored if the first run.

This is not exactly what has been propsed in the bug discussion, but please take a look and tell me what you think of the solution.