### PR TITLE
Add Proxy support

### DIFF
--- a/instaloader.py
+++ b/instaloader.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from instaloader.__main__ import main
+
+if __name__ == '__main__':
+    main()

--- a/instaloader.py
+++ b/instaloader.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-from instaloader.__main__ import main
-
-if __name__ == '__main__':
-    main()

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -215,11 +215,12 @@ class Instaloader:
                  slide: Optional[str] = None,
                  fatal_status_codes: Optional[List[int]] = None,
                  iphone_support: bool = True,
-                 title_pattern: Optional[str] = None):
+                 title_pattern: Optional[str] = None,
+                 proxies: Optional[dict] = None):
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
                                           request_timeout, rate_controller, fatal_status_codes,
-                                          iphone_support)
+                                          iphone_support, proxies)
 
         # configuration parameters
         self.dirname_pattern = dirname_pattern or "{target}"
@@ -1212,7 +1213,7 @@ class Instaloader:
         self.posts_download_loop(tagged_posts,
                                  target if target
                                  else (Path(_PostPathFormatter.sanitize_path(profile.username)) /
-                                       _PostPathFormatter.sanitize_path(':tagged')),
+                                       _PostPathFormatter.sanitize_path('__tagged')),
                                  fast_update, post_filter, takewhile=posts_takewhile)
         if latest_stamps is not None and tagged_posts.first_item is not None:
             latest_stamps.set_last_tagged_timestamp(profile.username, tagged_posts.first_item.date_local.astimezone())

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -186,6 +186,13 @@ class Instaloader:
     :param slide: :option:`--slide`
     :param fatal_status_codes: :option:`--abort-on`
     :param iphone_support: not :option:`--no-iphone`
+    :param proxies: A dictionary containing proxy URLs in the format accepted by
+        requests library.
+        If set to None, Instaloader will use the proxy configuration defined by standard
+        environment variables http_proxy, https_proxy, no_proxy and curl_ca_bundle
+        (uppercase variants of these variables are also supported).
+        For the detailed description of the format, see
+        https://docs.python-requests.org/en/master/user/advanced/#proxies
 
     .. attribute:: context
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1213,7 +1213,7 @@ class Instaloader:
         self.posts_download_loop(tagged_posts,
                                  target if target
                                  else (Path(_PostPathFormatter.sanitize_path(profile.username)) /
-                                       _PostPathFormatter.sanitize_path('__tagged')),
+                                       _PostPathFormatter.sanitize_path(':tagged')),
                                  fast_update, post_filter, takewhile=posts_takewhile)
         if latest_stamps is not None and tagged_posts.first_item is not None:
             latest_stamps.set_last_tagged_timestamp(profile.username, tagged_posts.first_item.date_local.astimezone())

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -228,7 +228,8 @@ class InstaloaderContext:
         # See: https://github.com/pgrimaud/instagram-user-feed/commit/96ad4cf54d1ad331b337f325c73e664999a6d066
         enc_password = '#PWD_INSTAGRAM_BROWSER:0:{}:{}'.format(int(datetime.now().timestamp()), passwd)
         login = session.post('https://www.instagram.com/accounts/login/ajax/',
-                             data={'enc_password': enc_password, 'username': user}, allow_redirects=True, proxies=self._proxies)
+                             data={'enc_password': enc_password, 'username': user},
+                             allow_redirects=True, proxies=self._proxies)
         try:
             resp_json = login.json()
         except json.decoder.JSONDecodeError as err:
@@ -331,7 +332,8 @@ class InstaloaderContext:
             if is_other_query:
                 self._rate_controller.wait_before_query('other')
 
-            resp = sess.get('https://{0}/{1}'.format(host, path), params=params, allow_redirects=False, proxies=self._proxies)
+            resp = sess.get('https://{0}/{1}'.format(host, path), params=params, allow_redirects=False,
+                    proxies=self._proxies)
             if resp.status_code in self.fatal_status_codes:
                 redirect = " redirect to {}".format(resp.headers['location']) if 'location' in resp.headers else ""
                 raise AbortDownloadException("Query to https://{}/{} responded with \"{} {}\"{}".format(


### PR DESCRIPTION
This change adds the ability to specify SOCKS or other proxies to be used by Instaloader when making HTTP requests. 

Here is an example of creating Instaloader object with SOCKS5 proxy:

```
pdef = 'socks5h://%s:%d' % (...)
proxies = { 'http': pdef, 'https': pdef }
L = Instaloader(proxies=proxies, user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0')
```

Currently the changes affect only Instaloader and InstaloaderContext objects, not the CLI. The appropriate options should be added.
The documentation also was not updated.
