### PR TITLE
Pick best video (#1022)

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -533,7 +533,10 @@ class InstaloaderContext:
 
         :raises QueryReturnedNotFoundException: When the server responds with a 404.
         :raises QueryReturnedForbiddenException: When the server responds with a 403.
-        :raises ConnectionException: When request failed."""
+        :raises ConnectionException: When request failed.
+        
+        .. versionadded:: 4.7.6
+        """
         with self.get_anonymous_session() as anonymous_session:
             resp = anonymous_session.head(url, allow_redirects=allow_redirects)
         if resp.status_code == 200:

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -534,7 +534,7 @@ class InstaloaderContext:
         :raises QueryReturnedNotFoundException: When the server responds with a 404.
         :raises QueryReturnedForbiddenException: When the server responds with a 403.
         :raises ConnectionException: When request failed.
-        
+
         .. versionadded:: 4.7.6
         """
         with self.get_anonymous_session() as anonymous_session:

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -528,7 +528,7 @@ class InstaloaderContext:
         :raises ConnectionException: When download repeatedly failed."""
         self.write_raw(self.get_raw(url), filename)
 
-    def head(self, url: str, allow_redirects: Optional[bool] = None) -> requests.Response:
+    def head(self, url: str, allow_redirects: bool = False) -> requests.Response:
         """HEAD a URL anonymously.
 
         :raises QueryReturnedNotFoundException: When the server responds with a 404.

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -384,7 +384,7 @@ class Post:
             if self._context.is_logged_in:
                 try:
                     for version in self._iphone_struct['video_versions']:
-                            url_candidates.append(get_size(version['url']))
+                        url_candidates.append(get_size(version['url']))
                 except (InstaloaderException, KeyError, IndexError) as err:
                     self._context.error('{} Unable to fetch high quality video version of {}.'.format(err, self))
             url_candidates.sort()

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -384,7 +384,7 @@ class Post:
             if self._context.is_logged_in:
                 try:
                     for version in self._iphone_struct['video_versions']:
-	                        url_candidates.append(get_size(version['url']))
+                            url_candidates.append(get_size(version['url']))
                 except (InstaloaderException, KeyError, IndexError) as err:
                     self._context.error('{} Unable to fetch high quality video version of {}.'.format(err, self))
             url_candidates.sort()
@@ -1118,7 +1118,7 @@ class StoryItem:
             if self._context.is_logged_in:
                 try:
                     for version in self._iphone_struct['video_versions']:
-	                        url_candidates.append(get_size(version['url']))
+                        url_candidates.append(get_size(version['url']))
                 except (InstaloaderException, KeyError, IndexError) as err:
                     self._context.error('{} Unable to fetch high quality video version of {}.'.format(err, self))
             url_candidates.sort()

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -383,8 +383,8 @@ class Post:
                 url_candidates.append(get_size(self._node['video_url']))
             if self._context.is_logged_in:
                 try:
-                    self._iphone_struct['video_versions'].sort(key=lambda x: x['height'])
-                    url_candidates.append(get_size(self._iphone_struct['video_versions'][-1]['url']))
+                    for version in self._iphone_struct['video_versions']:
+	                        url_candidates.append(get_size(version['url']))
                 except (InstaloaderException, KeyError, IndexError) as err:
                     self._context.error('{} Unable to fetch high quality video version of {}.'.format(err, self))
             url_candidates.sort()
@@ -1117,8 +1117,8 @@ class StoryItem:
             url_candidates.append(get_size(self._node['video_resources'][-1]['src']))
             if self._context.is_logged_in:
                 try:
-                    self._iphone_struct['video_versions'].sort(key=lambda x: x['height'])
-                    url_candidates.append(get_size(self._iphone_struct['video_versions'][-1]['url']))
+                    for version in self._iphone_struct['video_versions']:
+	                        url_candidates.append(get_size(version['url']))
                 except (InstaloaderException, KeyError, IndexError) as err:
                     self._context.error('{} Unable to fetch high quality video version of {}.'.format(err, self))
             url_candidates.sort()

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -380,10 +380,16 @@ class Post:
             if 'video_url' in self._node:
                 url_candidates.append(get_size(self._node['video_url']))
             if self._context.is_logged_in:
-                try:
-                    for version in self._iphone_struct['video_versions']:
+                success = False
+                err = None
+                for version in self._iphone_struct['video_versions']:
+                    try:
                         url_candidates.append(get_size(version['url']))
-                except (InstaloaderException, KeyError, IndexError) as err:
+                    except (InstaloaderException, KeyError, IndexError) as e:
+                        err = e
+                    else:
+                        success = True
+                if not success:
                     self._context.error('{} Unable to fetch high quality video version of {}.'.format(err, self))
             url_candidates.sort()
             return url_candidates[-1][1]
@@ -1114,10 +1120,16 @@ class StoryItem:
             url_candidates = []
             url_candidates.append(get_size(self._node['video_resources'][-1]['src']))
             if self._context.is_logged_in:
-                try:
-                    for version in self._iphone_struct['video_versions']:
+                success = False
+                err = None
+                for version in self._iphone_struct['video_versions']:
+                    try:
                         url_candidates.append(get_size(version['url']))
-                except (InstaloaderException, KeyError, IndexError) as err:
+                    except (InstaloaderException, KeyError, IndexError) as e:
+                        err = e
+                    else:
+                        success = True
+                if not success:
                     self._context.error('{} Unable to fetch high quality video version of {}.'.format(err, self))
             url_candidates.sort()
             return url_candidates[-1][1]

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -6,8 +6,6 @@ from collections import namedtuple
 from datetime import datetime
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
 
-import requests
-
 from . import __version__
 from .exceptions import *
 from .instaloadercontext import InstaloaderContext
@@ -376,7 +374,7 @@ class Post:
     def video_url(self) -> Optional[str]:
         """URL of the video, or None."""
         def get_size(url):
-            return requests.head(url).headers.get('Content-Length', 0), url
+            return self._context.head(url, allow_redirects=True).headers.get('Content-Length', 0), url
         if self.is_video:
             url_candidates = []
             if 'video_url' in self._node:
@@ -1111,7 +1109,7 @@ class StoryItem:
     def video_url(self) -> Optional[str]:
         """URL of the video, or None."""
         def get_size(url):
-            return requests.head(url).headers.get('Content-Length', 0), url
+            return self._context.head(url, allow_redirects=True).headers.get('Content-Length', 0), url
         if self.is_video:
             url_candidates = []
             url_candidates.append(get_size(self._node['video_resources'][-1]['src']))


### PR DESCRIPTION
This fixes #1022.

Also, Instaloader supports to download single post which works with Stories. But the returned data is slightly different and can't be properly handled by existing `Post` class. I patched this part as well. 

They are called `typename` = `StoryImage` and `StoryVideo` (NOT `GraphStoryImage` or `GraphStoryVideo` returned from the Stories timeline as `StoryItem`.)

Weirdly, the `StoryVideo` returned by single post API doesn't behave like `GraphStoryVideo` returned by Stories timeline either. It has no `self._node['video_url']` or `self._node['video_resources']`. So you can only get the video from `self._iphone_struct['video_versions']`.

In long term, I think it's better we either create a base class `Item` which both `StoryItem` and `Post` can inherit from; or just merge the two. This can dramatically reduce the redundancy of code in `structures.py`. 