### PR TITLE
Handle StoryImage & StoryVideo in `download_post`

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -695,12 +695,12 @@ class Instaloader:
                                                             mtime=post.date_local, filename_suffix=suffix)
                 else:
                     downloaded = False
-        elif post.typename == 'GraphImage':
+        elif post.typename in ['GraphImage', 'StoryImage']:
             # Download picture
             if self.download_pictures:
                 downloaded = (not _already_downloaded(filename + ".jpg") and
                               self.download_pic(filename=filename, url=post.url, mtime=post.date_local))
-        elif post.typename == 'GraphVideo':
+        elif post.typename in ['GraphVideo', 'StoryVideo']:
             # Download video thumbnail (--no-pictures implies --no-video-thumbnails)
             if self.download_pictures and self.download_video_thumbnails:
                 with self.context.error_catcher("Video thumbnail of {}".format(post)):

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -105,7 +105,7 @@ class Post:
     @staticmethod
     def supported_graphql_types() -> List[str]:
         """The values of __typename fields that the :class:`Post` class can handle."""
-        return ["GraphImage", "GraphVideo", "GraphSidecar"]
+        return ["GraphImage", "GraphVideo", "GraphSidecar", "StoryImage", "StoryVideo"]
 
     def _asdict(self):
         node = self._node


### PR DESCRIPTION
Instaloader supports to download single post which works with Stories. But the returned data is slightly different and can't be properly handled by existing Post class. I patched this part as well.

They are called typename = StoryImage and StoryVideo (NOT GraphStoryImage or GraphStoryVideo returned from the Stories timeline as StoryItem.)

Also note: weirdly, the StoryVideo returned by single post API doesn't behave like GraphStoryVideo returned by Stories timeline either. It has no self._node['video_url'] or self._node['video_resources']. So you can only get the video from self._iphone_struct['video_versions'].