### PR TITLE
Fix the issue with folder names starting with dots

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -146,6 +146,10 @@ class _PostPathFormatter(_ArbitraryItemFormatter):
     def sanitize_path(ret: str) -> str:
         """Replaces '/' with similar looking Division Slash and some other illegal filename characters on Windows."""
         ret = ret.replace('/', '\u2215')
+
+        if ret.startswith('.'):
+            ret = ret.replace('.', '\u2024', 1)
+
         if platform.system() == 'Windows':
             ret = ret.replace(':', '\uff1a').replace('<', '\ufe64').replace('>', '\ufe65').replace('\"', '\uff02')
             ret = ret.replace('\\', '\ufe68').replace('|', '\uff5c').replace('?', '\ufe16').replace('*', '\uff0a')


### PR DESCRIPTION
If you try to use `instaloader` to retrieve highlights that are grouped by naming it `.` or `..` you'll be having a problem with your OS. Besides, files starting with dots in Linux OS will be considered hidden folders, and you'll have some trouble seeing/moving them unless you use extra commands.

This commit uses the existing folder naming sanitization function and extends its capabilities for the above-mentioned case.

Basically, it will replace folders that start with a dot (".") into another similar one ("․")․
