### PR TITLE
datetime style formatting options doesn't return offset

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -3,7 +3,7 @@ import lzma
 import re
 from base64 import b64decode, b64encode
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
@@ -225,16 +225,14 @@ class Post:
     @property
     def date_local(self) -> datetime:
         """Timestamp when the post was created (local time zone)."""
-        return datetime.fromtimestamp(self._node["date"]
-                                      if "date" in self._node
-                                      else self._node["taken_at_timestamp"])
+        timestamp_date = self.get_timestamp_date_created()
+        tzinfo = timezone(timedelta(hours=self.get_timezone_offset(timestamp_date)))
+        return datetime.fromtimestamp(timestamp_date, tzinfo)
 
     @property
     def date_utc(self) -> datetime:
         """Timestamp when the post was created (UTC)."""
-        return datetime.utcfromtimestamp(self._node["date"]
-                                         if "date" in self._node
-                                         else self._node["taken_at_timestamp"])
+        return datetime.utcfromtimestamp(self.get_timestamp_date_created())
 
     @property
     def date(self) -> datetime:
@@ -274,6 +272,17 @@ class Post:
             edges = self._field('edge_sidecar_to_children', 'edges')
             return len(edges)
         return 1
+
+    def get_timestamp_date_created(self) -> float:
+        """Timestamp when the post was created"""
+        return (self._node["date"]
+                if "date" in self._node
+                else self._node["taken_at_timestamp"])
+
+    def get_timezone_offset(self, timestamp_date) -> float:
+        """Timestamp offset for a given date"""
+        diff_total_seconds = (datetime.fromtimestamp(timestamp_date) - datetime.utcfromtimestamp(timestamp_date)).total_seconds()
+        return diff_total_seconds / 3600
 
     def get_is_videos(self) -> List[bool]:
         """

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -225,8 +225,12 @@ class Post:
     @property
     def date_local(self) -> datetime:
         """Timestamp when the post was created (local time zone)."""
+        def get_timedelta(timestamp) -> timedelta:
+            """Datetime time delta for a given date"""
+            return datetime.fromtimestamp(timestamp) - datetime.utcfromtimestamp(timestamp)
+
         timestamp_date = self.get_timestamp_date_created()
-        tzinfo = timezone(timedelta(hours=self.get_timezone_offset(timestamp_date)))
+        tzinfo = timezone(get_timedelta(timestamp_date))
         return datetime.fromtimestamp(timestamp_date, tzinfo)
 
     @property
@@ -278,11 +282,6 @@ class Post:
         return (self._node["date"]
                 if "date" in self._node
                 else self._node["taken_at_timestamp"])
-
-    def get_timezone_offset(self, timestamp_date) -> float:
-        """Timestamp offset for a given date"""
-        diff_total_seconds = (datetime.fromtimestamp(timestamp_date) - datetime.utcfromtimestamp(timestamp_date)).total_seconds()
-        return diff_total_seconds / 3600
 
     def get_is_videos(self) -> List[bool]:
         """

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -226,7 +226,7 @@ class Post:
     def date_local(self) -> datetime:
         """Timestamp when the post was created (local time zone)."""
         def get_timedelta(timestamp) -> timedelta:
-            """Datetime time delta for a given date"""
+            """Timedelta for a given date"""
             return datetime.fromtimestamp(timestamp) - datetime.utcfromtimestamp(timestamp)
 
         timestamp_date = self.get_timestamp_date_created()

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1084,7 +1084,12 @@ class StoryItem:
     @property
     def date_local(self) -> datetime:
         """Timestamp when the StoryItem was created (local time zone)."""
-        return datetime.fromtimestamp(self._node['taken_at_timestamp'])
+        def get_timedelta(timestamp) -> timedelta:
+            """Timedelta for a given date"""
+            return datetime.fromtimestamp(timestamp) - datetime.utcfromtimestamp(timestamp)
+
+        tzinfo = timezone(get_timedelta(self._node['taken_at_timestamp']))
+        return datetime.fromtimestamp(self._node['taken_at_timestamp'], tzinfo)
 
     @property
     def date_utc(self) -> datetime:


### PR DESCRIPTION
- A motivation for this change, e.g.
  - Fixes issue #1305.
  - More general: from `--post-metadata-txt="{date_local:%Y-%m-%dT%H:%M:%S.%f%z}"`  %z in datetime style formatting options doesn't return offset

This is my very first time collaborating with the community, also this is one of my first projects with python, with this implementation what I do is substracting creation date in local time zone vs creation date in UTC, with that offset I can obtain the timezone info.
