### PR TITLE
Endless loop when receiving comments

### DIFF
--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -133,14 +133,15 @@ class NodeIterator(Iterator[T]):
             return item
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])
-            page_index, data = self._page_index, self._data
-            try:
-                self._page_index = 0
-                self._data = query_response
-            except KeyboardInterrupt:
-                self._page_index, self._data = page_index, data
-                raise
-            return self.__next__()
+            if self._data['edges'] != query_response['edges']:
+                page_index, data = self._page_index, self._data
+                try:
+                    self._page_index = 0
+                    self._data = query_response
+                except KeyboardInterrupt:
+                    self._page_index, self._data = page_index, data
+                    raise
+                return self.__next__()
         raise StopIteration()
 
     @property


### PR DESCRIPTION
- **A motivation for this change, e.g.**
  - Fixes #1017 #1143 #910 
  - More general: 
There is currently a problem with Instagram that sporadically the comments do not come to an end and can be scraped endlessly.
The has_next_page-flag (inside the request response) is always true although the comments are repeated.
This error does not always occur, but mainly with larger profiles and the consequence is that you quickly run into an HTTP 429 Error (Too Many Requests).
The problem can also be reproduced in the browser

Test data: https://www.instagram.com/p/CVyEdhbIXPG/

- **The changes proposed in this pull request**
-  change the nodeiterator __next__ method to check if the response is the same than before

- The completeness of this change
  - Is it just a proof of concept? It's just a poc 
  - Can we help you at some point? 
