### PR TITLE
Fix --dirname-pattern {target} placeholder (#580)

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -155,7 +155,7 @@ i.e. ``profile``, ``#hashtag``, ``%location id``, ``:feed``, etc. and therein sa
 posts in files named after the post's timestamp.
 
 :option:`--dirname-pattern` allows to configure the directory name of each
-target. The default is ``--dirname-pattern={target}``. In the dirname
+target. The default is ``--dirname-pattern={profile}/{target}``. In the dirname
 pattern, the token ``{target}`` is replaced by the target name, and
 ``{profile}`` is replaced by the owner of the post which is downloaded.
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -218,7 +218,7 @@ class Instaloader:
                                           iphone_support)
 
         # configuration parameters
-        self.dirname_pattern = dirname_pattern or "{target}"
+        self.dirname_pattern = dirname_pattern or "{profile}/{target}"
         self.filename_pattern = filename_pattern or "{date_utc}_UTC"
         if title_pattern is not None:
             self.title_pattern = title_pattern
@@ -909,8 +909,7 @@ class Instaloader:
             name = user_highlight.owner_username
             highlight_target = (filename_target
                                 if filename_target
-                                else (Path(_PostPathFormatter.sanitize_path(name)) /
-                                      _PostPathFormatter.sanitize_path(user_highlight.title)))  # type: Union[str, Path]
+                                else Path(_PostPathFormatter.sanitize_path(user_highlight.title))) # type: Union[str, Path]
             self.context.log("Retrieving highlights \"{}\" from profile {}".format(user_highlight.title, name))
             self.download_highlight_cover(user_highlight, highlight_target)
             totalcount = user_highlight.itemcount


### PR DESCRIPTION
This PR fixes issue #580

The issue is that when downloading highlights using --dirname-pattern, the {target} placeholder was being expanded to {profile}/&lt;highlight-title&gt;, with no way to separate these two components from the command line.

The changes in this PR make it so that {target} is replaced only with &lt;highlight-title&gt;, while changing the default --dirname-pattern to {profile}/{target} for backward compatibility.

<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
