### PR TITLE
check if profile is private when downloading stories

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1394,7 +1394,7 @@ class Instaloader:
                     self.save_metadata_json(json_filename, profile)
 
                 # Catch some errors
-                if tagged or igtv or highlights or posts:
+                if tagged or igtv or highlights or posts or stories:
                     if (not self.context.is_logged_in and
                             profile.is_private):
                         raise LoginRequiredException("--login=USERNAME required.")


### PR DESCRIPTION

<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes #1402 .
  - More general: What problem does the pull request solve?
  -raises an error if account is private

- The changes proposed in this pull request
-  it checks if a profile is private before downloading stories = 

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
