### PR TITLE
Mention regex will now be restricted to ASCII

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -347,7 +347,7 @@ class Post:
         # support Unicode and a word/beginning of string delimiter at the beginning to ensure
         # that no email addresses join the list of mentions.
         # http://blog.jstassen.com/2016/03/code-regex-for-instagram-username-and-hashtags/
-        mention_regex = re.compile(r"(?:^|\W|_)(?:@)(\w(?:(?:\w|(?:\.(?!\.))){0,28}(?:\w))?)")
+        mention_regex = re.compile(r"(?:^|\W|_)(?:@)(\w(?:(?:\w|(?:\.(?!\.))){0,28}(?:\w))?)", re.ASCII)
         return re.findall(mention_regex, self.caption.lower())
 
     @property


### PR DESCRIPTION
This attempts to fix https://github.com/instaloader/instaloader/issues/1455 by restricting mentions to only being ASCII.
<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
