### PR TITLE
added fix for infinity loading next query in nodeiterator if query_re…

### DIFF
--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -133,7 +133,7 @@ class NodeIterator(Iterator[T]):
             return item
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])
-            if self._data['edges'] != query_response['edges']:
+            if self._data['edges'] != query_response['edges'] and len(query_response['edges']) > 0:
                 page_index, data = self._page_index, self._data
                 try:
                     self._page_index = 0


### PR DESCRIPTION
…sponse has next_page but _data['edges'] is size 0

  - Fixes  #1347 as a better/improved solution (and probably also #1422).

  - What problem does the pull request solve?
The last fix in #1347 was a partially great solution unless instagram did change the response logic for some queries. 
Currently they return empty "edges arrays" despite the presence of "next_page: true" in query response content.

This leads to an endless loop in the nodeiterator and coherently to the 429 error (this is probably also a part of the error in #1422 ).

You can reproduce this behavior by saving posts with comments from: 

https://www.instagram.com/laura_isabell.gntm22.official/

(particulary this post:

https://www.instagram.com/p/CbFSldpriVy/

will lead to an endless loop respectively to the 429 error)

- The changes proposed in this pull request

  - Is it just a proof of concept?
  No.

  - Do you consider it ready to be merged or is it a draft?
It is considered ready to be merged.
