### PR TITLE
add --output parameter

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -7,6 +7,7 @@ import re
 import sys
 from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
 from typing import List, Optional
+from pathlib import Path
 
 from . import (AbortDownloadException, BadCredentialsException, Instaloader, InstaloaderException,
                InvalidArgumentException, Post, Profile, ProfileNotExistsException, StoryItem,
@@ -411,6 +412,8 @@ def main():
                         help='Disable user interaction, i.e. do not print messages (except errors) and fail '
                              'if login credentials are needed but not given. This makes Instaloader suitable as a '
                              'cron job.')
+    g_misc.add_argument('-o', '--output',
+                        help='Write to file instead of stdout. Path to file, to which the output will be written.')
     g_misc.add_argument('-h', '--help', action='help', help='Show this help message and exit.')
     g_misc.add_argument('--version', action='version', help='Show version number and exit.',
                         version=__version__)
@@ -467,7 +470,8 @@ def main():
                              fatal_status_codes=args.abort_on,
                              iphone_support=not args.no_iphone,
                              title_pattern=args.title_pattern,
-                             sanitize_paths=args.sanitize_paths)
+                             sanitize_paths=args.sanitize_paths,
+                             output_path=Path(args.output_path))
         _main(loader,
               args.profile,
               username=args.login.lower() if args.login is not None else None,

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -15,7 +15,7 @@ from . import (AbortDownloadException, BadCredentialsException, Instaloader, Ins
 from .instaloader import (get_default_session_filename, get_default_stamps_filename)
 from .instaloadercontext import default_user_agent
 from .lateststamps import LatestStamps
-from .util.output import StandardWriter, FileWriter, QuietWriter
+from .util.output import DefaultWriter, FileWriter, QuietWriter
 
 
 def usage_string():
@@ -105,7 +105,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
         except FileNotFoundError as err:
             if sessionfile is not None:
                 instaloader.context.writer.error(err)
-                if not isinstance(instaloader.context.writer, StandardWriter):
+                if not isinstance(instaloader.context.writer, DefaultWriter):
                     print(err, file=sys.stderr)
             instaloader.context.log("Session file does not exist yet - Logging in.")
         if not instaloader.context.is_logged_in or username != instaloader.test_login():
@@ -120,7 +120,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
                             break
                         except BadCredentialsException as err:
                             instaloader.context.error(err)
-                            if not isinstance(instaloader.context.writer, StandardWriter):
+                            if not isinstance(instaloader.context.writer, DefaultWriter):
                                 print(err, file=sys.stderr)
                             pass
             else:
@@ -238,12 +238,12 @@ def _main(instaloader: Instaloader, targetlist: List[str],
     except KeyboardInterrupt:
         message = "\nInterrupted by user."
         instaloader.context.error(message)
-        if not isinstance(instaloader.context.writer, StandardWriter):
+        if not isinstance(instaloader.context.writer, DefaultWriter):
             print(message, file=sys.stderr)
     except AbortDownloadException as exc:
         message = "\nDownload aborted: {}.".format(exc)
         instaloader.context.error(message)
-        if not isinstance(instaloader.context.writer, StandardWriter):
+        if not isinstance(instaloader.context.writer, DefaultWriter):
             print(message, file=sys.stderr)
     # Save session if it is useful
     if instaloader.context.is_logged_in:
@@ -431,7 +431,7 @@ def main():
 
     args = parser.parse_args()
 
-    writer = StandardWriter()
+    writer = DefaultWriter()
     if args.quiet:
         writer = QuietWriter()
     elif args.output is not None:
@@ -443,7 +443,7 @@ def main():
             message = "--login=USERNAME required to download stories."
             writer.error(message)
             # print to stderr too, because info is important
-            if not isinstance(writer, StandardWriter):
+            if not isinstance(writer, DefaultWriter):
                 print(message, file=sys.stderr)
             args.stories = False
             if args.stories_only:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -236,6 +236,7 @@ class Instaloader:
                  writer: OutputWriter = None):
 
         writer = DefaultWriter() if writer is None else writer
+        self.writer = writer
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
                                           request_timeout, rate_controller, fatal_status_codes,

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -24,7 +24,7 @@ from .nodeiterator import NodeIterator, resumable_iteration
 from .sectioniterator import SectionIterator
 from .structures import (Hashtag, Highlight, JsonExportable, Post, PostLocation, Profile, Story, StoryItem,
                          load_structure_from_file, save_structure_to_file, PostSidecarNode, TitlePic)
-from .util.output import OutputWriter, StandardWriter
+from .util.output import OutputWriter, DefaultWriter
 
 
 def _get_config_dir() -> str:
@@ -235,7 +235,7 @@ class Instaloader:
                  sanitize_paths: bool = False,
                  writer: OutputWriter = None):
 
-        writer = StandardWriter() if writer is None else writer
+        writer = DefaultWriter() if writer is None else writer
 
         self.context = InstaloaderContext(sleep, quiet, user_agent, max_connection_attempts,
                                           request_timeout, rate_controller, fatal_status_codes,

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -17,7 +17,7 @@ import requests
 import requests.utils
 
 from .exceptions import *
-from .util.output import OutputWriter, StandardWriter
+from .util.output import OutputWriter, DefaultWriter
 
 
 def copy_session(session: requests.Session, request_timeout: Optional[float] = None) -> requests.Session:
@@ -68,7 +68,7 @@ class InstaloaderContext:
         self._root_rhx_gis = None
         self.two_factor_auth_pending = None
         self.iphone_support = iphone_support
-        self.writer = writer if writer is not None else StandardWriter()
+        self.writer = writer if writer is not None else DefaultWriter()
 
         # error log, filled with error() and printed at the end of Instaloader.main()
         self.error_log = []                      # type: List[str]
@@ -123,7 +123,7 @@ class InstaloaderContext:
             for err in self.error_log:
                 self.writer.error(err)
 
-            if not isinstance(self.writer, StandardWriter):
+            if not isinstance(self.writer, DefaultWriter):
                 print(message)
                 for err in self.error_log:
                     print(err)

--- a/instaloader/util/output.py
+++ b/instaloader/util/output.py
@@ -9,10 +9,10 @@ class OutputWriter:
     Interface that is faithful to the builtin ``print`` function.
     """
     def write(self, *args, sep=' ', end='\n', flush=False):
-        raise NotImplemented
+        raise NotImplementedError
 
     def error(self, *args, sep=' ', end='\n', flush=False):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class DefaultWriter(OutputWriter):
@@ -43,7 +43,7 @@ class FileWriter(OutputWriter):
         :param end: end of message
         :param flush: has no effect
         """
-        self._write_to_file(list(args), sep, end)
+        self._write_to_file(list(args), sep=sep, end=end)
 
     def error(self, *args, sep=' ', end='\n', flush=False):
         """
@@ -53,14 +53,15 @@ class FileWriter(OutputWriter):
         :param end: end of message
         :param flush: has no effect
         """
-        self._write_to_file(['ERROR: '] + list(args), sep, end)
+        self._write_to_file(['ERROR: '] + list(args), sep=sep, end=end)
 
     def _write_to_file(self, *args, sep: str, end: str):
         args = [str(arg) for arg in args]
         message = sep.join(args)
         message += end
 
-        open(self.output_file, encoding='UTF-8', mode='a').write(message)
+        with open(self.output_file, encoding='UTF-8', mode='a') as logfile:
+            logfile.write(message)
 
 
 class QuietWriter(OutputWriter):

--- a/instaloader/util/output.py
+++ b/instaloader/util/output.py
@@ -5,19 +5,22 @@ from pathlib import Path
 
 
 class OutputWriter:
-    def write(self, msg: str):
+    """
+    Interface that is faithful to the builtin ``print`` function.
+    """
+    def write(self, *args, sep=' ', end='\n', flush=False):
         raise NotImplemented
 
-    def error(self, msg: str):
+    def error(self, *args, sep=' ', end='\n', flush=False):
         raise NotImplemented
 
 
 class StandardWriter(OutputWriter):
-    def write(self, msg: str):
-        print(msg)
+    def write(self, *args, sep=' ', end='\n', flush=False):
+        print(args, sep=sep, end=end, flush=flush)
 
-    def error(self, msg: str):
-        print(msg, file=sys.stderr)
+    def error(self, *args, sep=' ', end='\n', flush=False):
+        print(args, sep=sep, end=end, flush=flush, file=sys.stderr)
 
 
 class FileWriter(OutputWriter):
@@ -33,29 +36,37 @@ class FileWriter(OutputWriter):
             if os.path.exists(filepath):
                 print('File exists, overwriting file')
 
-    def write(self, msg: str):
+    def write(self, *args, sep=' ', end='\n', flush=False):
         """
         Writes normal output.
-        :param msg: Message
+        :param sep: seperator
+        :param end: end of message
+        :param flush: has no effect
         """
-        self._write_to_file(msg)
+        self._write_to_file(list(args), sep, end)
 
-    def error(self, msg: str):
+    def error(self, *args, sep=' ', end='\n', flush=False):
         """
         Writes error output.
         Prefixes ``ERROR:`` to message if writing to file, else writes to ``stderr``.
-        :param msg: Message
+        :param sep: seperator
+        :param end: end of message
+        :param flush: has no effect
         """
-        self._write_to_file(f'ERROR: {msg}')
+        self._write_to_file(['ERROR: '] + list(args), sep, end)
 
-    def _write_to_file(self, msg: str):
-        open(self.output_file, encoding='UTF-8', mode='a').write(f'{msg}\n')
+    def _write_to_file(self, *args, sep: str, end: str):
+        args = [str(arg) for arg in args]
+        message = sep.join(args)
+        message += end
+
+        open(self.output_file, encoding='UTF-8', mode='a').write(message)
 
 
 class QuietWriter(OutputWriter):
     """Does nothing"""
-    def write(self, msg: str):
+    def write(self, *args, sep=' ', end='\n', flush=False):
         pass
 
-    def error(self, msg: str):
+    def error(self, *args, sep=' ', end='\n', flush=False):
         pass

--- a/instaloader/util/output.py
+++ b/instaloader/util/output.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from typing import Optional
+from pathlib import Path
+
+
+class OutputWriter:
+    def write(self, msg: str):
+        raise NotImplemented
+
+    def error(self, msg: str):
+        raise NotImplemented
+
+
+class StandardWriter(OutputWriter):
+    def write(self, msg: str):
+        print(msg)
+
+    def error(self, msg: str):
+        print(msg, file=sys.stderr)
+
+
+class FileWriter(OutputWriter):
+    """Class that handles the output that the program generates."""
+    def __init__(self, filepath: Optional[Path] = None):
+        """
+        :param filepath: Optional[Path], if set, all output will be written to said file.
+        """
+        if filepath:
+            self.output_file = filepath
+            # print to stdout
+            print(f'Writing output to file "{filepath}"')
+            if os.path.exists(filepath):
+                print('File exists, overwriting file')
+
+    def write(self, msg: str):
+        """
+        Writes normal output.
+        :param msg: Message
+        """
+        self._write_to_file(msg)
+
+    def error(self, msg: str):
+        """
+        Writes error output.
+        Prefixes ``ERROR:`` to message if writing to file, else writes to ``stderr``.
+        :param msg: Message
+        """
+        self._write_to_file(f'ERROR: {msg}')
+
+    def _write_to_file(self, msg: str):
+        open(self.output_file, encoding='UTF-8', mode='a').write(f'{msg}\n')
+
+
+class QuietWriter(OutputWriter):
+    """Does nothing"""
+    def write(self, msg: str):
+        pass
+
+    def error(self, msg: str):
+        pass

--- a/instaloader/util/output.py
+++ b/instaloader/util/output.py
@@ -15,7 +15,7 @@ class OutputWriter:
         raise NotImplemented
 
 
-class StandardWriter(OutputWriter):
+class DefaultWriter(OutputWriter):
     def write(self, *args, sep=' ', end='\n', flush=False):
         print(args, sep=sep, end=end, flush=flush)
 


### PR DESCRIPTION

<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->

As mentioned in Issue #1480, I added a `--output` option, which will write to a file, instead of `stdout`.

I created a de-facto interface, from which the most important methods are inherited.

There are three Writer-classes:
- `DefaultWriter`
    Prints to `stdout`
- `FileWriter`
    append to a file, regardless if it exists or not (but user is warned that file exists if it does)
- `QuietWriter`
    does nothing at all
