### PR TITLE
Fix incorrect error messages when certain requests fail

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1335,7 +1335,8 @@ class Instaloader:
                 profile_from_id = Profile.from_id(self.context, profile_id)
                 newname = profile_from_id.username
                 if profile_name == newname:
-                    self.context.error(f"Warning: Profile {profile_name} could not be retrieved by its name, but by its ID.")
+                    self.context.error(
+                        f"Warning: Profile {profile_name} could not be retrieved by its name, but by its ID.")
                     return profile_from_id
                 self.context.error("Profile {0} has changed its name to {1}.".format(profile_name, newname))
                 if latest_stamps is None:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1334,6 +1334,9 @@ class Instaloader:
                                                                                                   profile_id))
                 profile_from_id = Profile.from_id(self.context, profile_id)
                 newname = profile_from_id.username
+                if profile_name == newname:
+                    self.context.error("Profile {0} could not be retrieved by its name, but by its ID.".format(profile_name))
+                    return profile_from_id
                 self.context.error("Profile {0} has changed its name to {1}.".format(profile_name, newname))
                 if latest_stamps is None:
                     if ((format_string_contains_key(self.dirname_pattern, 'profile') or

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1335,7 +1335,7 @@ class Instaloader:
                 profile_from_id = Profile.from_id(self.context, profile_id)
                 newname = profile_from_id.username
                 if profile_name == newname:
-                    self.context.error("Profile {0} could not be retrieved by its name, but by its ID.".format(profile_name))
+                    self.context.error(f"Warning: Profile {profile_name} could not be retrieved by its name, but by its ID.")
                     return profile_from_id
                 self.context.error("Profile {0} has changed its name to {1}.".format(profile_name, newname))
                 if latest_stamps is None:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -772,7 +772,8 @@ class Profile:
             similar_profiles = [profile.username for profile in top_search_results.get_profiles()]
             if similar_profiles:
                 if self.username in similar_profiles:
-                    raise ProfileNotExistsException(f"Profile {self.username} seems to exist, but could not be loaded.") from err
+                    raise ProfileNotExistsException(
+                        f"Profile {self.username} seems to exist, but could not be loaded.") from err
                 raise ProfileNotExistsException('Profile {} does not exist.\nThe most similar profile{}: {}.'
                                                 .format(self.username,
                                                         's are' if len(similar_profiles) > 1 else ' is',

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -771,6 +771,8 @@ class Profile:
             top_search_results = TopSearchResults(self._context, self.username)
             similar_profiles = [profile.username for profile in top_search_results.get_profiles()]
             if similar_profiles:
+                if self.username in similar_profiles:
+                    raise ProfileNotExistsException("Profile {} seems to exist, but could not be loaded.".format(self.username))
                 raise ProfileNotExistsException('Profile {} does not exist.\nThe most similar profile{}: {}.'
                                                 .format(self.username,
                                                         's are' if len(similar_profiles) > 1 else ' is',

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -772,7 +772,7 @@ class Profile:
             similar_profiles = [profile.username for profile in top_search_results.get_profiles()]
             if similar_profiles:
                 if self.username in similar_profiles:
-                    raise ProfileNotExistsException("Profile {} seems to exist, but could not be loaded.".format(self.username))
+                    raise ProfileNotExistsException(f"Profile {self.username} seems to exist, but could not be loaded.") from err
                 raise ProfileNotExistsException('Profile {} does not exist.\nThe most similar profile{}: {}.'
                                                 .format(self.username,
                                                         's are' if len(similar_profiles) > 1 else ' is',


### PR DESCRIPTION
This PR aims to fix the symptoms described in #1530, where error messages contradict themselves. It does _not_ fix the underlying problem (“Could not find "window._sharedData" in html response.“), though. Still, I think this is worth it, since profile loading might break in a similar fashion some time in the future.

I'm new to this codebase, so I do lack the “bigger picture”.

---

### a) handle case where `Profile.from_id` works, but `Profile.from_username` doesn't

https://github.com/instaloader/instaloader/blob/385c6c8a353458b8e1f5d1eacd98a714a41e9fc0/instaloader/instaloader.py#L1326-L1337

These are the local variables of interest:
```py
profile_id == 1234
profile == None
profile_name == 'somename'
newname == 'somename'
```
And here's what happens:
- `Profile.from_username` raises `ProfileNotExistsException`
- It's caught afterwards
- `profile_id` is read from the file
- `profile is None` since it wasn't found earlier
- > Trying to find profile somename using its unique ID 1234.
- `Profile.from_id` succeeds
- **Instaloader falsely concludes that the profile has changed its name, since it could not be found using the old name, but using the ID. In reality, `Profile.from_username` failed for some other reason, and the username remained unchanged.**

---

### b) Handle case where `QueryReturnedNotFoundException` lies and `similar_profiles` contains the exact username

https://github.com/instaloader/instaloader/blob/385c6c8a353458b8e1f5d1eacd98a714a41e9fc0/instaloader/structures.py#L764-L772

> Profile somename does not exist.
> The most similar profile is: somename.

Here, Instaloader tries to help by suggesting similar usernames, but doesn't notice that it's actually the one we wanted. It just wasn't able to load it, but since we catch a `QueryReturnedNotFoundException`, it's plausible to assume that the profile really does not exist.

The exception (in my case) is thrown here:
https://github.com/instaloader/instaloader/blob/385c6c8a353458b8e1f5d1eacd98a714a41e9fc0/instaloader/instaloadercontext.py#L356
An alternative approach would be to raise another kind of exception there. 🤷🏼‍♂️


<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
