### PR TITLE
Fix mention and hashtag regexes and normalize profile biographies

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -382,9 +382,8 @@ class Post:
         """List of all lowercased hashtags (without preceeding #) that occur in the Post's caption."""
         if not self.caption:
             return []
-        # This regular expression is from jStassen, adjusted to use Python's \w to support Unicode
-        # http://blog.jstassen.com/2016/03/code-regex-for-instagram-username-and-hashtags/
-        hashtag_regex = re.compile(r"(?:#)(\w(?:(?:\w|(?:\.(?!\.))){0,28}(?:\w))?)")
+        # This regular expression is by MiguelX413
+        hashtag_regex = re.compile(r"(?:#)((?:\w){1,150})")
         return re.findall(hashtag_regex, self.caption.lower())
 
     @property
@@ -396,7 +395,7 @@ class Post:
         # support Unicode and a word/beginning of string delimiter at the beginning to ensure
         # that no email addresses join the list of mentions.
         # http://blog.jstassen.com/2016/03/code-regex-for-instagram-username-and-hashtags/
-        mention_regex = re.compile(r"(?:^|\W|_)(?:@)(\w(?:(?:\w|(?:\.(?!\.))){0,28}(?:\w))?)", re.ASCII)
+        mention_regex = re.compile(r"(?:^|[^\w\n]|_])(?:@)(\w(?:(?:\w|(?:\.(?!\.))){0,28}(?:\w))?)", re.ASCII)
         return re.findall(mention_regex, self.caption.lower())
 
     @property

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -861,7 +861,7 @@ class Profile:
 
     @property
     def biography(self) -> str:
-        return self._metadata('biography')
+        return normalize("NFC", self._metadata('biography'))
 
     @property
     def blocked_by_viewer(self) -> bool:


### PR DESCRIPTION
This pull request fixes the totally incorrect regex for hashtags and also makes sure profile biographies are normalized.
The hashtag regex was totally incorrect in both the maximum length of 30 and inclusion of periods.
Profile biographies were not being normalized until now.
<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
