### PR TITLE
Handle StoryImage in StoryItem.url

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1204,7 +1204,8 @@ class StoryItem:
     @property
     def url(self) -> str:
         """URL of the picture / video thumbnail of the StoryItem"""
-        if self.typename in ["GraphStoryImage", "StoryImage"] and self._context.iphone_support and self._context.is_logged_in:
+        if self.typename in ["GraphStoryImage", "StoryImage"] and \
+                self._context.iphone_support and self._context.is_logged_in:
             try:
                 orig_url = self._iphone_struct['image_versions2']['candidates'][0]['url']
                 url = re.sub(r'([?&])se=\d+&?', r'\1', orig_url).rstrip('&')

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1204,7 +1204,7 @@ class StoryItem:
     @property
     def url(self) -> str:
         """URL of the picture / video thumbnail of the StoryItem"""
-        if self.typename == "GraphStoryImage" and self._context.iphone_support and self._context.is_logged_in:
+        if self.typename in ["GraphStoryImage", "StoryImage"] and self._context.iphone_support and self._context.is_logged_in:
             try:
                 orig_url = self._iphone_struct['image_versions2']['candidates'][0]['url']
                 url = re.sub(r'([?&])se=\d+&?', r'\1', orig_url).rstrip('&')


### PR DESCRIPTION
A further fix about issue mentioned in #1238.

After @aandergr 's commit https://github.com/instaloader/instaloader/commit/c0e5d0475bff1507c930d4ceefb5d66686caee5d, a single story can be properly handled; however, the original issue still somewhat exists: higher quality image from iPhone API won't be fetched if a single Story is feeded in and then `.download_storyitem` is called, due to its type being "StoryImage" instead of "GraphStoryImage". 

This fixes it.
Thanks!
