### PR TITLE
fixed fetching a users profile information

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -767,7 +767,7 @@ class Profile:
                 metadata = self._context.get_iphone_json(f'api/v1/users/web_profile_info/?username={self.username}',
                                                          params={})
 		
-		if metadata['data']['user'] is None:
+                if metadata['data']['user'] is None:
                     raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
 		
                 self._node = metadata['data']['user']

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -764,8 +764,9 @@ class Profile:
     def _obtain_metadata(self):
         try:
             if not self._has_full_metadata:
-                metadata = self._context.get_json('{}/feed/'.format(self.username), params={})
-                self._node = metadata['entry_data']['ProfilePage'][0]['graphql']['user']
+                metadata = self._context.get_iphone_json(f'api/v1/users/web_profile_info/?username={self.username}',
+                                                         params={})
+                self._node = metadata['data']['user']
                 self._has_full_metadata = True
         except (QueryReturnedNotFoundException, KeyError) as err:
             top_search_results = TopSearchResults(self._context, self.username)

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -766,6 +766,10 @@ class Profile:
             if not self._has_full_metadata:
                 metadata = self._context.get_iphone_json(f'api/v1/users/web_profile_info/?username={self.username}',
                                                          params={})
+		
+		if metadata['data']['user'] is None:
+                    raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
+		
                 self._node = metadata['data']['user']
                 self._has_full_metadata = True
         except (QueryReturnedNotFoundException, KeyError) as err:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -766,10 +766,8 @@ class Profile:
             if not self._has_full_metadata:
                 metadata = self._context.get_iphone_json(f'api/v1/users/web_profile_info/?username={self.username}',
                                                          params={})
-		
                 if metadata['data']['user'] is None:
                     raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
-		
                 self._node = metadata['data']['user']
                 self._has_full_metadata = True
         except (QueryReturnedNotFoundException, KeyError) as err:


### PR DESCRIPTION
Retrieving a users profile was not possible anymore, due to internal changes of instagram. 

It seems to work fine when switching to the new 'api/v1/users/web_profile_info/?username=xy' endpoint.

Up to now I just tested that retrieving the profile info as well as posts is working with this fix, so it is still a WIP.
I'm not too familiar with the internals of instaloader so maybe someone with more knowledge can help out to verify if everything works fine again...

When final this should fix #1553 as well as #1560
