### PR TITLE
Handle pinned posts with --fast-update and --latest-stamps

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1010,7 +1010,10 @@ class Instaloader:
                 enabled=self.resume_prefix is not None
         ) as (is_resuming, start_index):
             for number, post in enumerate(posts, start=start_index + 1):
-                if (max_count is not None and number > max_count) or not takewhile(post):
+                should_stop = not takewhile(post)
+                if should_stop and post.is_pinned:
+                    continue
+                if (max_count is not None and number > max_count) or should_stop:
                     break
                 if displayed_count is not None:
                     self.context.log("[{0:{w}d}/{1:{w}d}] ".format(number, displayed_count,

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1042,7 +1042,7 @@ class Instaloader:
                         except PostChangedException:
                             post_changed = True
                             continue
-                    if fast_update and not downloaded and not post_changed:
+                    if fast_update and not downloaded and not post_changed and not post.is_pinned:
                         # disengage fast_update for first post when resuming
                         if not is_resuming or number > 0:
                             break

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -129,7 +129,9 @@ class NodeIterator(Iterator[T]):
                 raise
             item = self._node_wrapper(node)
             if self._first_node is None:
-                self._first_node = node
+                pinned = 'pinned_for_users' in node and bool(node['pinned_for_users'])
+                if not pinned:
+                    self._first_node = node
             return item
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -179,7 +179,7 @@ class NodeIterator(Iterator[T]):
         function as the `is_first` parameter when creating the class.
 
         .. versionadded:: 4.8
-        .. versionchanged:: 4.10
+        .. versionchanged:: 4.9.2
            What is considered the first item can be overridden.
         """
         return self._node_wrapper(self._first_node) if self._first_node is not None else None

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -977,7 +977,7 @@ class Profile:
             {'id': self.userid},
             'https://www.instagram.com/{0}/'.format(self.username),
             self._metadata('edge_owner_to_timeline_media'),
-            self._make_is_newest_checker()
+            Profile._make_is_newest_checker()
         )
 
     def get_saved_posts(self) -> NodeIterator[Post]:
@@ -1011,7 +1011,7 @@ class Profile:
             lambda n: Post(self._context, n, self if int(n['owner']['id']) == self.userid else None),
             {'id': self.userid},
             'https://www.instagram.com/{0}/'.format(self.username),
-            is_first=self._make_is_newest_checker()
+            is_first=Profile._make_is_newest_checker()
         )
 
     def get_igtv_posts(self) -> NodeIterator[Post]:
@@ -1029,11 +1029,12 @@ class Profile:
             {'id': self.userid},
             'https://www.instagram.com/{0}/channel/'.format(self.username),
             self._metadata('edge_felix_video_timeline'),
-            self._make_is_newest_checker()
+            Profile._make_is_newest_checker()
         )
 
-    def _make_is_newest_checker(self) -> Callable[[Post], bool]:
-        newest_date: Optional[Datetime] = None
+    @staticmethod
+    def _make_is_newest_checker() -> Callable[[Post], bool]:
+        newest_date: Optional[datetime] = None
         def is_newest(p: Post) -> bool:
             nonlocal newest_date
             post_date = p.date_local

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -648,7 +648,7 @@ class Post:
     def is_pinned(self) -> bool:
         """True if this Post has been pinned by at least one user.
 
-        .. versionadded: 4.10"""
+        .. versionadded: 4.9.2"""
         return 'pinned_for_users' in self._node and bool(self._node['pinned_for_users'])
 
 

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -644,6 +644,13 @@ class Post:
                                       loc.get('lat'), loc.get('lng'))
         return self._location
 
+    @property
+    def is_pinned(self) -> bool:
+        """True if this Post has been pinned by at least one user.
+
+        .. versionadded: 4.10"""
+        return bool(self._node['pinned_for_users'])
+
 
 class Profile:
     """

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -649,7 +649,7 @@ class Post:
         """True if this Post has been pinned by at least one user.
 
         .. versionadded: 4.10"""
-        return bool(self._node['pinned_for_users'])
+        return 'pinned_for_users' in self._node and bool(self._node['pinned_for_users'])
 
 
 class Profile:


### PR DESCRIPTION
IG now allows posts to be pinned, and they are return first by `Profile.get_posts()`. This makes `--fast-update` and `--latest-stamp` stop too early (as the first post is considered already downloaded) and posts newer than the pinned post are not downloaded. See #1582 and #1584.

- **The completeness of this change**: It's complete, hopefully
- **Is it just a proof of concept?**: No
- **Is the documentation updated (if appropriate)?** I think no changes are necessary
- **Do you consider it ready to be merged or is it a draft?**: Implementation is complete, but further tests would be useful
- **Can we help you at some point?** Yes

The ideal solution would be to return pinned posts in their proper chronological order. This would require storing pinned posts in a "pending" list and add some logic in the `__next__` function to return either a real post or one of the pinned posts according to the post time. But this would require saving (and restoring) a lot more state when the process is interrupted.

Instead I'm thinking of just treating pinned posts differently:
* With `--fast-update`, pinned posts are not considered when deciding whether to stop downloading. They'll be skipped because they already exist, but download will only stop when reaching a regular post that has been downloaded.
* Similarly, with `--latest-stamps`, pinned posts will be skipped if older than the latest saved post, but downloads continue and only stop when a regular post that is older than the last saved post is reached.
