### PR TITLE
Add save and load session from dict

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -591,11 +591,15 @@ class Instaloader:
         """Saves internally stored :class:`requests.Session` object to :class:`dict`.
 
         :raises LoginRequiredException: If called without being logged in.
+
+        .. versionadded:: 4.10
         """
         return self.context.save_session()
 
     def load_session(self, username: str, session_data: dict) -> None:
         """Internally stores :class:`requests.Session` object from :class:`dict`.
+
+        .. versionadded:: 4.10
         """
         self.context.load_session(username, session_data)
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -587,6 +587,19 @@ class Instaloader:
         self.download_title_pic(hashtag.profile_pic_url, '#' + hashtag.name, 'profile_pic', None)
 
     @_requires_login
+    def save_session(self) -> dict:
+        """Saves internally stored :class:`requests.Session` object to :class:`dict`.
+
+        :raises LoginRequiredException: If called without being logged in.
+        """
+        return self.context.save_session()
+
+    def load_session(self, username: str, session_data: dict) -> None:
+        """Internally stores :class:`requests.Session` object from :class:`dict`.
+        """
+        self.context.load_session(username, session_data)
+
+    @_requires_login
     def save_session_to_file(self, filename: Optional[str] = None) -> None:
         """Saves internally stored :class:`requests.Session` object.
 

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -170,21 +170,29 @@ class InstaloaderContext:
         session.request = partial(session.request, timeout=self.request_timeout) # type: ignore
         return session
 
-    def save_session_to_file(self, sessionfile):
-        """Not meant to be used directly, use :meth:`Instaloader.save_session_to_file`."""
-        pickle.dump(requests.utils.dict_from_cookiejar(self._session.cookies), sessionfile)
+    def save_session(self):
+        """Not meant to be used directly, use :meth:`Instaloader.save_session`."""
+        return requests.utils.dict_from_cookiejar(self._session.cookies)
 
-    def load_session_from_file(self, username, sessionfile):
-        """Not meant to be used directly, use :meth:`Instaloader.load_session_from_file`."""
+    def load_session(self, username, sessiondata):
+        """Not meant to be used directly, use :meth:`Instaloader.load_session`."""
         session = requests.Session()
-        session.cookies = requests.utils.cookiejar_from_dict(pickle.load(sessionfile))
+        session.cookies = requests.utils.cookiejar_from_dict(sessiondata)
         session.headers.update(self._default_http_header())
         session.headers.update({'X-CSRFToken': session.cookies.get_dict()['csrftoken']})
         # Override default timeout behavior.
         # Need to silence mypy bug for this. See: https://github.com/python/mypy/issues/2427
-        session.request = partial(session.request, timeout=self.request_timeout) # type: ignore
+        session.request = partial(session.request, timeout=self.request_timeout)  # type: ignore
         self._session = session
         self.username = username
+
+    def save_session_to_file(self, sessionfile):
+        """Not meant to be used directly, use :meth:`Instaloader.save_session_to_file`."""
+        pickle.dump(self.save_session(), sessionfile)
+
+    def load_session_from_file(self, username, sessionfile):
+        """Not meant to be used directly, use :meth:`Instaloader.load_session_from_file`."""
+        self.load_session(username, pickle.load(sessionfile))
 
     def test_login(self) -> Optional[str]:
         """Not meant to be used directly, use :meth:`Instaloader.test_login`."""


### PR DESCRIPTION
This PR adds `Instaloader.save_session` and `Instaloader.load_session`. The session object can now be imported/exported as a regular Python `dict`. 

This can be really useful when, for example, you are working in a serverless environment and want to easily store/retrieve the session for reuse from a database (like *DynamoDB*) without relying on expensive file system I/O operations.

- **Is it just a proof of concept?**: No, it's production ready
- **Is the documentation updated (if appropriate)?**: Yes
- **Do you consider it ready to be merged or is it a draft?**: Ready to merge and ship on the next release
- **Can we help you at some point?**: Nothing much to do anymore, but everything can be improved 😄

