### PR TITLE
Added `is_reposted`, `original_poster_profile` in `StoryItem`

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1292,7 +1292,7 @@ class StoryItem:
             url_candidates.sort()
             return url_candidates[-1][1]
         return None
-    
+
     @property
     def is_reposted(self) -> bool:
         """True if the StoryItem is reposted by other profile."""

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1123,7 +1123,7 @@ class StoryItem:
         self._context = context
         self._node = node
         self._owner_profile = owner_profile
-	self._original_poster_username = None
+        self._original_poster_username = None
         self._iphone_struct_ = None
         if 'iphone_struct' in node:
             # if loaded from JSON with load_structure_from_file()

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1092,6 +1092,7 @@ class StoryItem:
         self._context = context
         self._node = node
         self._owner_profile = owner_profile
+	self._original_poster_username = None
         self._iphone_struct_ = None
         if 'iphone_struct' in node:
             # if loaded from JSON with load_structure_from_file()
@@ -1259,6 +1260,22 @@ class StoryItem:
                 return version_urls[0]
             url_candidates.sort()
             return url_candidates[-1][1]
+        return None
+    
+    @property
+    def is_reposted(self) -> bool:
+        """True if the StoryItem is reposted by other profile."""
+        for tappable_object in self._node['tappable_objects']:
+            if tappable_object['__typename'] == "GraphTappableMention":
+                self._original_poster_username = tappable_object['username']
+                return True
+        return False
+
+    @property
+    def original_poster_profile(self) -> Profile:
+        """:class:`Profile` instance of the story item's original poster."""
+        if self.is_reposted:
+            return Profile.from_username(self._context, self._original_poster_username)
         return None
 
 


### PR DESCRIPTION
A lot of times the "owner" is reposting a story he was tagged into. I am calling the person who tagged the "owner" as "original_poster".

The GraphQL query from such a reposted story has information inside the `tappable_objects` key of each `StoryItem`.
For example for a reposted story it looks like this:

```
"tappable_objects": [
                        {
                            "__typename": "GraphTappableMention",
                            "x": 0.49967163378806606,
                            "y": 0.5150924938267181,
                            "width": 0.9216036185381431,
                            "height": 0.9216036185381431,
                            "rotation": 0.0,
                            "custom_title": null,
                            "attribution": null,
                            "username": "username",
                            "full_name": "User Name",
                            "is_private": false
                        }
                    ]
```

And for a story that was NOT reposted there is nothing inside `tappable_objects` with the `__typename` of `GraphTappableMention`.

The functions I added are pretty self explanatory and I followed the structure the rest of the project has.



<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
