### PR TITLE
Write caption in text mode. Fix #1623

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -478,9 +478,8 @@ class Instaloader:
             self.context.log(pcaption, end=' ', flush=True)
         except UnicodeEncodeError:
             self.context.log('txt', end=' ', flush=True)
-        with open(filename, 'wb') as text_file:
-            with BytesIO(bcaption) as bio:
-                shutil.copyfileobj(cast(IO, bio), text_file)
+        with open(filename, 'w', encoding='UTF-8') as fio:
+            fio.write(caption)
         os.utime(filename, (datetime.now().timestamp(), mtime.timestamp()))
 
     def save_location(self, filename: str, location: PostLocation, mtime: datetime) -> None:


### PR DESCRIPTION
- A motivation for this change, e.g.
  - Fixes #1623 .

Write caption in text mode instead of binary mode, so the system newline separator (`\r\n` on Windows, for example) would be used instead of fixed `\n`. It shouldn't affect our duplication check on old caption file(s), since they're always compared with `\r\n` replaced with `\n`.
