### PR TITLE
Use api/v1/feed/reels_media endpoint to get story info

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1479,7 +1479,7 @@ class Highlight(Story):
         assert self._items is not None
         for item in self._items:
             if self._iphone_struct_ is not None:
-                for iphone_struct_item in self._iphone_struct['items']:
+                for iphone_struct_item in self._iphone_struct_['items']:
                     if iphone_struct_item['pk'] == int(item['id']):
                         item['iphone_struct'] = iphone_struct_item
                         break

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1451,14 +1451,6 @@ class Highlight(Story):
         """URL of the cropped version of the cover."""
         return self._node['cover_media_cropped_thumbnail']['url']
 
-    @property
-    def _iphone_struct(self) -> Dict[str, Any]:
-        if not self._context.iphone_support:
-            raise IPhoneSupportDisabledException("iPhone support is disabled.")
-        if not self._context.is_logged_in:
-            raise LoginRequiredException("--login required to access iPhone media info endpoint.")
-        return self._iphone_struct_
-
     def _fetch_items(self):
         if not self._items:
             self._items = self._context.graphql_query("45246d3fe16ccc6577e0bd297a5db1ab",

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -293,7 +293,7 @@ class Post:
                 url = re.sub(r'([?&])se=\d+&?', r'\1', orig_url).rstrip('&')
                 return url
             except (InstaloaderException, KeyError, IndexError) as err:
-                self._context.error('{} Unable to fetch high quality image version of {}.'.format(err, self))
+                self._context.error(f"Unable to fetch high quality image version of {self}: {err}")
         return self._node["display_url"] if "display_url" in self._node else self._node["display_src"]
 
     @property
@@ -357,8 +357,7 @@ class Post:
                             orig_url = carousel_media[idx]['image_versions2']['candidates'][0]['url']
                             display_url = re.sub(r'([?&])se=\d+&?', r'\1', orig_url).rstrip('&')
                         except (InstaloaderException, KeyError, IndexError) as err:
-                            self._context.error('{} Unable to fetch high quality image version of {}.'.format(
-                                err, self))
+                            self._context.error(f"Unable to fetch high quality image version of {self}: {err}")
                     yield PostSidecarNode(is_video=is_video, display_url=display_url,
                                           video_url=node['video_url'] if is_video else None)
 
@@ -953,7 +952,7 @@ class Profile:
             try:
                 return self._iphone_struct['hd_profile_pic_url_info']['url']
             except (InstaloaderException, KeyError) as err:
-                self._context.error('{} Unable to fetch high quality profile pic.'.format(err))
+                self._context.error(f"Unable to fetch high quality profile pic: {err}")
                 return self._metadata("profile_pic_url_hd")
         else:
             return self._metadata("profile_pic_url_hd")
@@ -1243,7 +1242,7 @@ class StoryItem:
                 url = re.sub(r'([?&])se=\d+&?', r'\1', orig_url).rstrip('&')
                 return url
             except (InstaloaderException, KeyError, IndexError) as err:
-                self._context.error('{} Unable to fetch high quality image version of {}.'.format(err, self))
+                self._context.error(f"Unable to fetch high quality image version of {self}: {err}")
         return self._node['display_resources'][-1]['src']
 
     @property

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1175,6 +1175,7 @@ class StoryItem:
             data = self._context.get_iphone_json(
                 path='api/v1/feed/reels_media/?reel_ids={}'.format(self.owner_id), params={}
             )
+            self._iphone_struct_ = {}
             for item in data['reels'][str(self.owner_id)]['items']:
                 if item['pk'] == self.mediaid:
                     self._iphone_struct_ = item

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1172,8 +1172,13 @@ class StoryItem:
         if not self._context.is_logged_in:
             raise LoginRequiredException("--login required to access iPhone media info endpoint.")
         if not self._iphone_struct_:
-            data = self._context.get_iphone_json(path='api/v1/media/{}/info/'.format(self.mediaid), params={})
-            self._iphone_struct_ = data['items'][0]
+            data = self._context.get_iphone_json(
+                path='api/v1/feed/reels_media/?reel_ids={}'.format(self.owner_id), params={}
+            )
+            for item in data['reels'][str(self.owner_id)]['items']:
+                if item['pk'] == self.mediaid:
+                    self._iphone_struct_ = item
+                    break
         return self._iphone_struct_
 
     @property


### PR DESCRIPTION
- A motivation for this change, e.g.
  - Fixes #1633 for stories.
 
- The changes proposed in this pull request
  - Use `api/v1/feed/reels_media` endpoint to download story iphone struct instead of the old `api/v1/media/`, which doesn't work with reshared stories.
  - Now also download entire iphone structs for all the stories in a Highlight first, instead of fetching them one by one.
- The completeness of this change
  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? No need
  - Do you consider it ready to be merged or is it a draft? Ready to merge

Using a different api endpoint for stories. It works for a batch I tested so far, re-shared or not.

I haven't got any example of "re-shared posts" from the original issue, so I can't really test them. The change currently is for story only.

It also now downloads entire iphone structs for all the stories in a Highlight first, instead of fetching them one by one. This saves us lots of iPhone API call when downloading highlights (and works with reshared stories if they are in highlights).