### PR TITLE
Don't use iPhone api when merely comparing profile_pic URL with existing one

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -562,7 +562,7 @@ class Instaloader:
         if latest_stamps is None:
             self.download_profilepic(profile)
             return
-        profile_pic_basename = profile.profile_pic_url.split('/')[-1].split('?')[0]
+        profile_pic_basename = profile.profile_pic_url_no_iphone.split('/')[-1].split('?')[0]
         saved_basename = latest_stamps.get_profile_pic(profile.username)
         if saved_basename == profile_pic_basename:
             return

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -958,6 +958,13 @@ class Profile:
         else:
             return self._metadata("profile_pic_url_hd")
 
+    @property
+    def profile_pic_url_no_iphone(self) -> str:
+        """Return URL of lower-quality profile picture.
+
+        .. versionadded:: 4.9.3"""
+        return self._metadata("profile_pic_url_hd")
+
     def get_profile_pic_url(self) -> str:
         """.. deprecated:: 4.0.3
 


### PR DESCRIPTION
### A motivation for this change, e.g.
Reduce iPhone API calls. Helps issues like #1676, #1658, etc.

### The changes proposed in this pull request
Don't try to use the iPhone API when merely comparing the profile pic URL with the local stamp.
    
This saves us some API calls when using `--latest-stamps`.

From what I can see, if you are updating lots of profiles, and most of them have no new posts (so no time wasted on checking posts), it would call this API for checking each profile pic way too fast and will got your account suspended (especially if you're using `--no-sleep`). This isn't needed because all the variant, including the web one, has the same remote URL (sans the query parameters). We only need to fetch from iPhone API when the avatar is actually changed. 

### The completeness of this change
Completed, ready to merge.