### PR TITLE
Fixes incorrect latest stamp when download is resumed (#1701)

### DIFF
--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -92,7 +92,6 @@ class NodeIterator(Iterator[T]):
         else:
             self._data = self._query()
         self._first_node: Optional[Dict] = None
-        self._first_item: Optional[T] = None
         self._is_first = is_first
 
     def _query(self, after: Optional[str] = None) -> Dict:
@@ -132,13 +131,11 @@ class NodeIterator(Iterator[T]):
                 raise
             item = self._node_wrapper(node)
             if self._is_first is not None:
-                if self._is_first(item, self._first_item):
+                if self._is_first(item, self.first_item):
                     self._first_node = node
-                    self._first_item = item
             else:
                 if self._first_node is None:
                     self._first_node = node
-                    self._first_item = item
             return item
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])
@@ -185,7 +182,7 @@ class NodeIterator(Iterator[T]):
         .. versionchanged:: 4.9.2
            What is considered the first item can be overridden.
         """
-        return self._first_item
+        return self._node_wrapper(self._first_node) if self._first_node is not None else None
 
     def freeze(self) -> FrozenNodeIterator:
         """Freeze the iterator for later resuming."""
@@ -230,7 +227,6 @@ class NodeIterator(Iterator[T]):
         self._data = frozen.remaining_data
         if frozen.first_node is not None:
             self._first_node = frozen.first_node
-            self._first_item = self._node_wrapper(self._first_node)
 
 
 @contextmanager

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -77,7 +77,7 @@ class NodeIterator(Iterator[T]):
                  query_variables: Optional[Dict[str, Any]] = None,
                  query_referer: Optional[str] = None,
                  first_data: Optional[Dict[str, Any]] = None,
-                 is_first: Optional[Callable[[T], bool]] = None):
+                 is_first: Optional[Callable[[T, Optional[T]], bool]] = None):
         self._context = context
         self._query_hash = query_hash
         self._edge_extractor = edge_extractor
@@ -92,6 +92,7 @@ class NodeIterator(Iterator[T]):
         else:
             self._data = self._query()
         self._first_node: Optional[Dict] = None
+        self._first_item: Optional[T] = None
         self._is_first = is_first
 
     def _query(self, after: Optional[str] = None) -> Dict:
@@ -131,11 +132,13 @@ class NodeIterator(Iterator[T]):
                 raise
             item = self._node_wrapper(node)
             if self._is_first is not None:
-                if self._is_first(item):
+                if self._is_first(item, self._first_item):
                     self._first_node = node
+                    self._first_item = item
             else:
                 if self._first_node is None:
                     self._first_node = node
+                    self._first_item = item
             return item
         if self._data['page_info']['has_next_page']:
             query_response = self._query(self._data['page_info']['end_cursor'])
@@ -182,7 +185,7 @@ class NodeIterator(Iterator[T]):
         .. versionchanged:: 4.9.2
            What is considered the first item can be overridden.
         """
-        return self._node_wrapper(self._first_node) if self._first_node is not None else None
+        return self._first_item
 
     def freeze(self) -> FrozenNodeIterator:
         """Freeze the iterator for later resuming."""
@@ -227,6 +230,7 @@ class NodeIterator(Iterator[T]):
         self._data = frozen.remaining_data
         if frozen.first_node is not None:
             self._first_node = frozen.first_node
+            self._first_item = self._node_wrapper(self._first_node)
 
 
 @contextmanager

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1039,17 +1039,8 @@ class Profile:
         )
 
     @staticmethod
-    def _make_is_newest_checker() -> Callable[[Post], bool]:
-        newest_date: Optional[datetime] = None
-        def is_newest(p: Post) -> bool:
-            nonlocal newest_date
-            post_date = p.date_local
-            if newest_date is None or post_date > newest_date:
-                newest_date = post_date
-                return True
-            else:
-                return False
-        return is_newest
+    def _make_is_newest_checker() -> Callable[[Post, Optional[Post]], bool]:
+        return lambda post, first: first is None or post.date_local > first.date_local
 
     def get_followers(self) -> NodeIterator['Profile']:
         """


### PR DESCRIPTION
**Motivation**: Fixes #1701.

Not only this fixes the problem, but it makes the code simpler. However, the type of the `is_first` callback has been changed. But sine this is a new feature (and very specific), I don't think this change will be a problem.

**Is it just a proof of concept?** No
**Is the documentation updated (if appropriate)?** Not necessary
**Do you consider it ready to be merged or is it a draft?** Ready
**Can we help you at some point?** This is a simple change and should be complete, but I'm open to suggestions
