### PR TITLE
download_pic: return if url is empty

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -337,6 +337,8 @@ class Instaloader:
         Returns true, if file was actually downloaded, i.e. updated."""
         if filename_suffix is not None:
             filename += '_' + filename_suffix
+        if not url:
+            return False
         urlmatch = re.search('\\.[a-z0-9]*\\?', url)
         file_extension = url[-3:] if urlmatch is None else urlmatch.group(0)[1:-1]
         nominal_filename = filename + '.' + file_extension


### PR DESCRIPTION

### A motivation for this change, e.g.
  - Fixes # 1460, #1718, #1728, etc.

### What problem does the pull request solve?
 
When parsing very old `StoryItem` from highlights, there is a chance that despite the metadata says `.is_video == True`, it actually does not have video URL in neither graphql nor iPhone API (server side issue, you can even see that with official web). 

This will cause `StoryItem.video_url` to return `None` and `download_pic` does not handle that well.

### The changes proposed in this pull requests
There are multiple ways to fix it: 
1) only attempt to call `download_pic` if url is valid; 
2) handle None `url` in `download_pic`. 

I personally think method 2 is better since it will deal with potential similar issues in other classes like `Post`.

Also a note: one may think we can just mark the item as `.is_video = False` if graphql does not return video URL. This is WRONG because as mentioned before, if you fetch story directly by mediaid or shortcode, it will not have `video_resources` URLs, but you can still get it from iPhone API.

### The completeness of this change
  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? N/A
  - Do you consider it ready to be merged or is it a draft? Ready to be merged
  - Can we help you at some point? Yes
