### PR TITLE
re-force to login when the session file is empty.

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -100,7 +100,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
             instaloader.context.error("Warning: Parameter \"{}\" for --login is not a valid username.".format(username))
         try:
             instaloader.load_session_from_file(username, sessionfile)
-        except FileNotFoundError as err:
+        except (FileNotFoundError, EOFError) as err:
             if sessionfile is not None:
                 print(err, file=sys.stderr)
             instaloader.context.log("Session file does not exist yet - Logging in.")


### PR DESCRIPTION
When the session file is empty, the script just throw an EOFError, but not asking the user to login again.
This change improved the error handling of the session managment.

```
Traceback (most recent call last):
  File "/usr/local/bin/instaloader", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/instaloader/__main__.py", line 471, in main
    _main(loader,
  File "/usr/local/lib/python3.10/site-packages/instaloader/__main__.py", line 102, in _main
    instaloader.load_session_from_file(username, sessionfile)
  File "/usr/local/lib/python3.10/site-packages/instaloader/instaloader.py", line 619, in load_session_from_file
    self.context.load_session_from_file(username, sessionfile)
  File "/usr/local/lib/python3.10/site-packages/instaloader/instaloadercontext.py", line 180, in load_session_from_file
    session.cookies = requests.utils.cookiejar_from_dict(pickle.load(sessionfile))
EOFError: Ran out of input

```
