### PR TITLE
Fixed downloading hashtags after first page

### DIFF
--- a/docs/as-module.rst
+++ b/docs/as-module.rst
@@ -34,9 +34,9 @@ picture, video or sidecar (set of multiple pictures/videos) posted in a user's
 profile. :class:`Instaloader` provides methods to iterate over Posts from a
 certain source::
 
-    for post in instaloader.Hashtag.from_name(L.context, 'cat').get_posts():
+    for post in instaloader.Profile.from_username(L.context, 'instagram').get_posts():
         # post is an instance of instaloader.Post
-        L.download_post(post, target='#cat')
+        L.download_post(post, target='instagram')
 
 :class:`Post` instances can be created with:
 

--- a/instaloader/sectioniterator.py
+++ b/instaloader/sectioniterator.py
@@ -29,7 +29,7 @@ class SectionIterator(Iterator[T]):
     def _query(self, max_id: Optional[str] = None) -> Dict[str, Any]:
         pagination_variables = {"max_id": max_id} if max_id is not None else {}
         return self._sections_extractor(
-            self._context.get_json(self._query_path, params={"__a": 1, **pagination_variables})
+            self._context.get_json(self._query_path, params={"__a": 1, "__d": "dis", **pagination_variables})
         )
 
     def __next__(self) -> T:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -47,12 +47,13 @@ class Post:
     """
     Structure containing information about an Instagram post.
 
-    Created by methods :meth:`Profile.get_posts`, :meth:`Instaloader.get_hashtag_posts`,
+    Created by methods :meth:`Profile.get_posts`, :meth:`Hashtag.get_posts_resumable`,
     :meth:`Instaloader.get_feed_posts` and :meth:`Profile.get_saved_posts`, which return iterators of Posts::
 
        L = Instaloader()
-       for post in L.get_hashtag_posts(HASHTAG):
-           L.download_post(post, target='#'+HASHTAG)
+       profile = Profile.from_username(L.context, USERNAME)
+       for post in profile.get_posts():
+           L.download_post(post, target=profile.username)
 
     Might also be created with::
 
@@ -1510,7 +1511,7 @@ class Hashtag:
 
     To then download the Hashtag's Posts, do::
 
-       for post in hashtag.get_posts():
+       for post in hashtag.get_posts_resumable():
           L.download_post(post, target="#"+hashtag.name)
 
     Also, this class implements == and is hashable.

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1647,7 +1647,7 @@ class Hashtag:
             conn = self._metadata("edge_hashtag_to_media")
             yield from (Post(self._context, edge["node"]) for edge in conn["edges"])
             while conn["page_info"]["has_next_page"]:
-                data = self._query({'__a': 1, 'max_id': conn["page_info"]["end_cursor"]})
+                data = self._query({'__a': 1, '__d': 'dis', 'max_id': conn["page_info"]["end_cursor"]})
                 conn = data["edge_hashtag_to_media"]
                 yield from (Post(self._context, edge["node"]) for edge in conn["edges"])
         except KeyError:


### PR DESCRIPTION
- **A motivation for this change, e.g.**

  - Fixes #1751
  - Fixes #1763

- **The changes proposed in this pull request**

  - Add the parameter `__d` to the url to prevent the request returning `"Sorry, something went wrong"` or `ConnectionException / JSONDecodeError` when using the deprecated method `Hashtag#get_posts`.
  - Replace references to `Instaloader#get_hashtag_posts` and `Hashtag#get_posts` in the examples documented.

- **The completeness of this change**

  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? N/A
  - Do you consider it ready to be merged or is it a draft? Ready to merge
