### PR TITLE
Fixed bug that was asking for 2FA code again and again.

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -208,6 +208,8 @@ class InstaloaderContext:
                                 'ig_vw': '1920', 'ig_cb': '1', 'csrftoken': '',
                                 's_network': '', 'ds_user_id': ''})
         session.headers.update(self._default_http_header())
+        #Getting mid cookie value
+        session.get("https://i.instagram.com/api/v1/web/login_page/")
         # Override default timeout behavior.
         # Need to silence mypy bug for this. See: https://github.com/python/mypy/issues/2427
         session.request = partial(session.request, timeout=self.request_timeout) # type: ignore
@@ -262,7 +264,8 @@ class InstaloaderContext:
                 # username is invalid.
                 raise InvalidArgumentException('Login error: User {} does not exist.'.format(user))
         # '{"authenticated": true, "user": true, "userId": ..., "oneTapPrompt": false, "status": "ok"}'
-        session.headers.update({'X-CSRFToken': login.cookies['csrftoken']})
+        if 'csrftoken' in login.cookies:
+            session.headers.update({'X-CSRFToken': login.cookies['csrftoken']})
         self._session = session
         self.username = user
 
@@ -287,7 +290,8 @@ class InstaloaderContext:
                 raise BadCredentialsException("2FA error: {}".format(resp_json['message']))
             else:
                 raise BadCredentialsException("2FA error: \"{}\" status.".format(resp_json['status']))
-        session.headers.update({'X-CSRFToken': login.cookies['csrftoken']})
+        if 'csrftoken' in login.cookies:
+            session.headers.update({'X-CSRFToken': login.cookies['csrftoken']})
         self._session = session
         self.username = user
         self.two_factor_auth_pending = None


### PR DESCRIPTION
This PR fixes the bug that caused the 2FA code to be asked again and again even though it was typed correctly. Fixes #1565, #1773, #1758, #1565, #1217 and many more.
No need to import cookies from any browser now.

<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
