### PR TITLE
Add copy proxies to new session

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -25,6 +25,7 @@ def copy_session(session: requests.Session, request_timeout: Optional[float] = N
     new = requests.Session()
     new.cookies = requests.utils.cookiejar_from_dict(requests.utils.dict_from_cookiejar(session.cookies))
     new.headers = session.headers.copy()
+    new.proxies = session.proxies.copy()
     # Override default timeout behavior.
     # Need to silence mypy bug for this. See: https://github.com/python/mypy/issues/2427
     new.request = partial(new.request, timeout=request_timeout) # type: ignore


### PR DESCRIPTION
Hi, I just needed to use proxies with this library and say an OpenPR on adding this functionality.

I figured there are some reviews needed to be resolved but minimal support to coping proxies to new session would solve my problem.

I've been setting proxies in my code like:
``` python
L.context._session.proxies = dict(http='[PROXY]', https='[PROXY]')
```  
then I saw the copy_session function used under the hood

I think this quick solution would be nice :+1: 