### PR TITLE
Detect redirects to https://i.instagram.com/accounts/login, fixes redirect loop

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -331,7 +331,8 @@ class InstaloaderContext:
             while resp.is_redirect:
                 redirect_url = resp.headers['location']
                 self.log('\nHTTP redirect from https://{0}/{1} to {2}'.format(host, path, redirect_url))
-                if redirect_url.startswith('https://www.instagram.com/accounts/login'):
+                if (redirect_url.startswith('https://www.instagram.com/accounts/login') or
+                    redirect_url.startswith('https://i.instagram.com/accounts/login')):
                     if not self.is_logged_in:
                         raise LoginRequiredException("Redirected to login page. Use --login.")
                     # alternate rate limit exceeded behavior


### PR DESCRIPTION
In some cases (possibly when requests are made to `i.instagram.com`), the redirect to login uses host `i.instagram.com` instead of `api.instagram.com`:

```
HTTP redirect from https://i.instagram.com/api/v1/users/web_profile_info/?username=profile to https://i.instagram.com/accounts/login/?next=/api/v1/users/web_profile_info/
```

This is not detected by instaload as a login request, and the application seems to enter a redirect loop, which results in getting 429 responses.

This change just adds the new URL to the detection of login required, letting the existing logic take over.

**Is it just a proof of concept?**: No
**Is the documentation updated (if appropriate)?** Not necessary
**Do you consider it ready to be merged or is it a draft?** Ready