### PR TITLE
Added property "entities" to Profile class

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -877,6 +877,21 @@ class Profile:
         return self._metadata('biography')
 
     @property
+    def entities(self) -> str:
+        '''This property will return a list or single ``string`` of the sponsored accounts/entities showed in the target profile
+        or ``No sponsors list.`` string.
+        '''
+        # Check if the target has entities.
+        if len(self._metadata('biography_with_entities')["entities"]) == 0:
+            return "No sponsors list."
+        else:
+            # If so, create the list/single string and return it.
+            sponsorsList = ""
+            for item in self._metadata('biography_with_entities')["entities"]:
+                sponsorsList = sponsorsList + f'{item["user"]["username"]}\n'
+            return sponsorsList
+
+    @property
     def blocked_by_viewer(self) -> bool:
         return self._metadata('blocked_by_viewer')
 

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -878,9 +878,7 @@ class Profile:
 
     @property
     def entities(self) -> str:
-        '''This property will return a list or single ``string`` of the sponsored accounts/entities showed in the target profile
-        or ``No sponsors list.`` string.
-        '''
+	'''This return a ``str`` of the sponsored accounts/entities showed in the target profile otherwise ``No sponsors list.`` string.'''
         # Check if the target has entities.
         if len(self._metadata('biography_with_entities')["entities"]) == 0:
             return "No sponsors list."

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -877,16 +877,15 @@ class Profile:
         return self._metadata('biography')
 
     @property
-    def entities(self) -> str:
-	'''This return a ``str`` of the sponsored accounts/entities showed in the target profile otherwise ``No sponsors list.`` string.'''
-        # Check if the target has entities.
+    def entities(self) -> list:
+        """Return a list of entities / sponsors"""
         if len(self._metadata('biography_with_entities')["entities"]) == 0:
             return "No sponsors list."
         else:
             # If so, create the list/single string and return it.
-            sponsorsList = ""
+            sponsorsList = []
             for item in self._metadata('biography_with_entities')["entities"]:
-                sponsorsList = sponsorsList + f'{item["user"]["username"]}\n'
+                sponsorsList.append(item["user"]["username"])
             return sponsorsList
 
     @property

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -876,18 +876,20 @@ class Profile:
     def biography(self) -> str:
         return self._metadata('biography')
 
-    @property
-    def entities(self) -> list:
-        """Return a list of entities / sponsors"""
-        if len(self._metadata('biography_with_entities')["entities"]) == 0:
-            return "No sponsors list."
-        else:
-            # If so, create the list/single string and return it.
-            sponsorsList = []
-            for item in self._metadata('biography_with_entities')["entities"]:
-                sponsorsList.append(item["user"]["username"])
-            return sponsorsList
+    def get_sponsors(self) -> List['Profile']:
+        """
+        Return a list of :class:`Profile` sponsors wich you can iterate over.
 
+        .. versionadded:: 4.10
+        """
+        if len(self._metadata('biography_with_entities')["entities"]) == 0:
+            return []
+        else:
+            sponsorsList = []
+            for sponsor in self._metadata('biography_with_entities')["entities"]:
+                sponsorsList.append(Profile.from_username(self._context, sponsor["user"]["username"]))
+            return sponsorsList
+        
     @property
     def blocked_by_viewer(self) -> bool:
         return self._metadata('blocked_by_viewer')


### PR DESCRIPTION
<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
Added a property for more metadata hoarding.

This property first will test if the target profile has entities, if not it will return the string:
`No sponsors list.`

Otherwise it will return a single `string\n` or a list of strings i.e:
`Sponsor1`
`Sponsor2`

This was an idea when i was creating a script for better and pretty organization of the data downloaded using IL lib.
Any advice for better coding, comment or related is appreciate, i am starting.

Edit 1, 2 and 3:
Using
`Python 3.11.2`
`Instaloader 4.9.6`

Here is the repo of that idea: [Repo](https://github.com/jamesphoenixcode/prettyIL)