### PR TITLE
Abort the download when redirected to login

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -335,8 +335,8 @@ class InstaloaderContext:
                     redirect_url.startswith('https://i.instagram.com/accounts/login')):
                     if not self.is_logged_in:
                         raise LoginRequiredException("Redirected to login page. Use --login.")
-                    # alternate rate limit exceeded behavior
-                    raise TooManyRequestsException("Redirected to login")
+                    raise AbortDownloadException("Redirected to login page. You've been logged, please wait " +
+                                                 "some time, recreate the session and try again")
                 if redirect_url.startswith('https://{}/'.format(host)):
                     resp = sess.get(redirect_url if redirect_url.endswith('/') else redirect_url + '/',
                                     params=params, allow_redirects=False)


### PR DESCRIPTION
This fixes #1882: instead of trying again, it aborts the process. If it happens during download, it should save the iterator for the next run, but for me this happens when fetching the profiles, before anything was downloaded. (During the download IG instead returns a 403 error instead.)

**Is it just a proof of concept?** No
**Is the documentation updated (if appropriate)?** Not necessary
**Do you consider it ready to be merged or is it a draft?** It's ready
**Can we help you at some point?** I don't see the need, but feel free to suggest another message.