### PR TITLE
Log the response when an abort status is received

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -372,8 +372,11 @@ class InstaloaderContext:
             resp = sess.get('https://{0}/{1}'.format(host, path), params=params, allow_redirects=False)
             if resp.status_code in self.fatal_status_codes:
                 redirect = " redirect to {}".format(resp.headers['location']) if 'location' in resp.headers else ""
-                raise AbortDownloadException("Query to https://{}/{} responded with \"{} {}\"{}:{}".format(
-                    host, path, resp.status_code, resp.reason, redirect, resp.text
+                body = ""
+                if resp.headers['Content-Type'].startswith('application/json'):
+                    body = ': ' + resp.text[:500] + ('…' if len(resp.text) > 501 else '')
+                raise AbortDownloadException("Query to https://{}/{} responded with \"{} {}\"{}{}".format(
+                    host, path, resp.status_code, resp.reason, redirect, body
                 ))
             while resp.is_redirect:
                 redirect_url = resp.headers['location']

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -372,8 +372,8 @@ class InstaloaderContext:
             resp = sess.get('https://{0}/{1}'.format(host, path), params=params, allow_redirects=False)
             if resp.status_code in self.fatal_status_codes:
                 redirect = " redirect to {}".format(resp.headers['location']) if 'location' in resp.headers else ""
-                raise AbortDownloadException("Query to https://{}/{} responded with \"{} {}\"{}".format(
-                    host, path, resp.status_code, resp.reason, redirect
+                raise AbortDownloadException("Query to https://{}/{} responded with \"{} {}\"{}:{}".format(
+                    host, path, resp.status_code, resp.reason, redirect, resp.text
                 ))
             while resp.is_redirect:
                 redirect_url = resp.headers['location']


### PR DESCRIPTION
This is a small change that adds the contents of the response to the log message when the download is aborted with one of the error codes specified with the command-line option `--abort-on`.

I find the contents to be useful, sometimes it just says "You've been logged out", sometimes something like "Challenge required". And it would help in the case of other errors as well.

**Is it just a proof of concept?** No
**Is the documentation updated (if appropriate)?** Not necessary
**Do you consider it ready to be merged or is it a draft?** It's ready
**Can we help you at some point?** Not necessary