### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -27,7 +27,7 @@ To **download all pictures and videos of a profile**, as well as the
 
     instaloader profile [profile ...]
 
-where ``profile`` is the name of a profile you want to download. Instead
+where ``profile`` is the instagram username of a profile you want to download. Instead
 of only one profile, you may also specify a list of profiles.
 
 To later **update your local copy** of that profiles, you may run
@@ -75,25 +75,23 @@ What to Download
 Instaloader supports the following targets:
 
 - ``profile``
-   Public profile, or private profile with :option:`--login`.
+   Posts from the feed of a public profile, or a private profile with :option:`--login`. 
+   The current profile picture is also downloaded. 
+   ``profile`` must be an instagram username. 
+   
+   If an already-downloaded profile has been renamed, 
+   Instaloader automatically finds it by its unique ID and renames the folder accordingly.
 
-   If an already-downloaded profile has been renamed, Instaloader automatically
-   finds it by its unique ID and renames the folder accordingly.
-
-   Besides the profile's posts, its current profile picture is downloaded. For
-   each profile you download,
+   The following options can be specified to instruct instaloader to download additional posts for each profile:
 
    - :option:`--stories`
-      instructs Instaloader to also **download the user's stories**,
+      Downloads current stories from the profile (requires :option:`--login`)
 
    - :option:`--highlights`
-      to **download the highlights of that profile**,
+      Downloads highlights of the profile (requires :option:`--login`)
 
    - :option:`--tagged`
-      to **download posts where the user is tagged**, and
-
-   - :option:`--igtv`
-      to **download IGTV videos**.
+      Downloads posts where the specified profile is tagged
 
 - ``"#hashtag"``
    Posts with a certain **hashtag** (the quotes are usually necessary).
@@ -101,20 +99,20 @@ Instaloader supports the following targets:
 - ``%location id``
    Posts tagged with a given location; the location ID is the numerical ID
    Instagram labels a location with (e.g.
-   \https://www.instagram.com/explore/locations/**362629379**/plymouth-naval-memorial/).
-   Requires :option:`--login`.
+   \https://www.instagram.com/explore/locations/**362629379**/plymouth-naval-memorial/)
+   (requires :option:`--login`).
 
    .. versionadded:: 4.2
 
 - ``:stories``
-   The currently-visible **stories** of your followees (requires
+   The currently-visible **stories** of the profiles you follow, i.e. your *followees* (requires
    :option:`--login`).
 
 - ``:feed``
    Your **feed** (requires :option:`--login`).
 
 - ``:saved``
-   Posts which are marked as **saved** (requires :option:`--login`).
+   Posts which are marked as **saved** by you (requires :option:`--login`).
 
 - ``@profile``
    All profiles that are followed by ``profile``, i.e. the *followees* of

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -135,6 +135,11 @@ What to Download of each Profile
 
    Also download IGTV videos.
 
+   .. note::
+
+      IGTV videos are now available on a profile feed and are downloaded automatically 
+      without specifying this option.
+
    .. versionadded:: 4.3
 
 Which Posts to Download


### PR DESCRIPTION
Minor updates to "What to Download" section of CLI usage

<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # . [NA]
  - More general: What problem does the pull request solve? Update doc information around IGTV and minor clean up. [Reading the current doc confused me a little so hoping this helps someone else too]
    

- The changes proposed in this pull request
  - Update profile target information to provide a tiny bit more clarity and consistency
  - Remove --igtv option information under profile target and add a note in Command Line Options since this option is redundant. [IGTV has combined with in-feed videos to form Instagram Video](https://techcrunch.com/2021/10/05/instagram-ditches-the-igtv-brand-combines-everything-but-reels-into-an-instagram-video-format/) therefore IGTV posts will be part of a profile feed and will be downloaded along with the profile posts. 
  - Minor updates to other download targets for consistency


- The completeness of this change
  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? Yes
  - Do you consider it ready to be merged or is it a draft? Yes
    - built using `make html` and checked the resulting html 
  - Can we help you at some point? Yes
-->
