### PR TITLE
added installation documentation adhering to PEP 668

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,15 @@
 
 ::
 
+    from pip
     $ pip3 install instaloader
+
+    $ instaloader profile [profile ...]
+
+    from source
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip3 install requirements.txt
 
     $ instaloader profile [profile ...]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2023.7.22
+charset-normalizer==3.3.0
+idna==3.4
+requests==2.31.0
+urllib3==2.0.7


### PR DESCRIPTION

<!--
As you might know, PEP 668 disallows users from installing packages globally so one might use a tool such as pipx to install instaloader.
Another option is cloning the repo and creating a virtual environment which isn't explained in the README file.
And this is what I changed. I also added a requirements.txt file so that the user doesn't have to look for the required packages himself.
-->
