### PR TITLE
Implemented fix to avoid simuntaneous use of --login and --load-cookies

### DIFF
--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -205,7 +205,7 @@ Instaloader to login.
    Supported browsers: Chrome, Firefox, Edge, Opera, Safari, Brave.
 
    After loading the cookies run the :option:`--login` option as it is required to download high quality media
-   and to make full use of instaloader's features.
+   and to make full use of Instaloader's features.
 
    .. versionadded:: 4.1
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -199,12 +199,15 @@ Instaloader to login.
 .. option:: --load-cookies BROWSER-NAME, -b BROWSER-NAME
 
    Use Instagram cookie in your browser to login.
+   This feature requires the browser_cookie3 library.
    Compatible with :option:`--cookiefile` if you want to load cookies from browser profiles.
    Incompatible with :option:`--login` due to potential username mismatch between user input and browser login.
    Supported browsers: Chrome, Firefox, Edge, Opera, Safari, Brave.
 
    After loading the cookies run the :option:`--login` option as it is required to download high quality media
    and to make full use of instaloader's features.
+
+   .. versionadded:: 4.1
 
 .. option:: --cookiefile COOKIE-FILE, -B COOKIE-FILE
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -207,7 +207,7 @@ Instaloader to login.
    After loading the cookies run the :option:`--login` option as it is required to download high quality media
    and to make full use of Instaloader's features.
 
-   .. versionadded:: 4.1
+   .. versionadded:: 4.11
 
 .. option:: --cookiefile COOKIE-FILE, -B COOKIE-FILE
 

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -198,7 +198,13 @@ Instaloader to login.
 
 .. option:: --load-cookies BROWSER-NAME, -b BROWSER-NAME
 
-   Use Instagram cookie in your browser to login (works with :option:`--login`). Supported browsers: Chrome, Firefox, Edge, Opera, Safari, Brave.
+   Use Instagram cookie in your browser to login.
+   Compatible with :option:`--cookiefile` if you want to load cookies from browser profiles.
+   Incompatible with :option:`--login` due to potential username mismatch between user input and browser login.
+   Supported browsers: Chrome, Firefox, Edge, Opera, Safari, Brave.
+
+   After loading the cookies run the :option:`--login` option as it is required to download high quality media
+   and to make full use of instaloader's features.
 
 .. option:: --cookiefile COOKIE-FILE, -B COOKIE-FILE
 

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -114,8 +114,8 @@ def import_session(browser, instaloader, cookiefile):
         instaloader.context.username = username
         print(f"{username} has been successfully logged in.")
         next_step_text = (f"Next: Run instaloader --login={username} as it is required to download high quality media "
-            "and to make full use of instaloader's features.")
-        print(textwrap.fill(next_step_text, width=80))
+                            "and to make full use of instaloader's features.")
+        print(textwrap.fill(next_step_text))
 
 def _main(instaloader: Instaloader, targetlist: List[str],
           username: Optional[str] = None, password: Optional[str] = None,
@@ -148,7 +148,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
     # load cookies if browser is not None
     if browser and bc3_library:
         import_session(browser.lower(), instaloader, cookiefile)
-    elif browser and bc3_library is False:
+    elif browser and not bc3_library:
         raise SystemExit("browser_cookie3 library is needed to load cookies from browsers")
     # Login, if desired
     if username is not None:

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -140,6 +140,12 @@ def _main(instaloader: Instaloader, targetlist: List[str],
     if latest_stamps_file is not None:
         latest_stamps = LatestStamps(latest_stamps_file)
         instaloader.context.log(f"Using latest stamps from {latest_stamps_file}.")
+    # load cookies if browser is not None
+    if browser is not None:
+        if bc3_library:
+            import_session(browser.lower(), instaloader, cookiefile)
+        else:
+            raise SystemExit("browser_cookie3 library is needed to load cookies from browsers")
     # Login, if desired
     if username is not None:
         if not re.match(r"^[A-Za-z0-9._]+$", username):
@@ -150,11 +156,6 @@ def _main(instaloader: Instaloader, targetlist: List[str],
             if sessionfile is not None:
                 print(err, file=sys.stderr)
             instaloader.context.log("Session file does not exist yet - Logging in.")
-        if browser is not None:
-            if bc3_library:
-                import_session(browser.lower(), instaloader, cookiefile)
-            else:
-                raise SystemExit("browser_cookie3 library is needed to load cookies from browsers")
         if not instaloader.context.is_logged_in or username != instaloader.test_login():
             if password is not None:
                 try:
@@ -503,6 +504,9 @@ def main():
 
         if args.no_pictures and args.fast_update:
             raise SystemExit('--no-pictures and --fast-update cannot be used together.')
+
+        if args.login and args.load_cookies:
+            raise SystemExit('--load-cookies and --login cannot be used together.')
 
         # Determine what to download
         download_profile_pic = not args.no_profile_pic or args.profile_pic_only

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -95,6 +95,8 @@ def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
 
     if cookies:
         print(f"Cookies loaded successfully from {browser}")
+        print("Next: Run instaloader --login=USERNAME as it is required to download high quality media \
+            and to make full use of instaloader's features")
     else:
         print(f"No cookies found for Instagram in {browser}, Are you logged in succesfully in {browser}?")
 
@@ -141,11 +143,10 @@ def _main(instaloader: Instaloader, targetlist: List[str],
         latest_stamps = LatestStamps(latest_stamps_file)
         instaloader.context.log(f"Using latest stamps from {latest_stamps_file}.")
     # load cookies if browser is not None
-    if browser is not None:
-        if bc3_library:
-            import_session(browser.lower(), instaloader, cookiefile)
-        else:
-            raise SystemExit("browser_cookie3 library is needed to load cookies from browsers")
+    if browser and bc3_library:
+        import_session(browser.lower(), instaloader, cookiefile)
+    elif browser and bc3_library is False:
+        raise SystemExit("browser_cookie3 library is needed to load cookies from browsers")
     # Login, if desired
     if username is not None:
         if not re.match(r"^[A-Za-z0-9._]+$", username):

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -5,6 +5,7 @@ import datetime
 import os
 import re
 import sys
+import textwrap
 from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
 from typing import List, Optional
 
@@ -95,8 +96,6 @@ def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
 
     if cookies:
         print(f"Cookies loaded successfully from {browser}")
-        print("Next: Run instaloader --login=USERNAME as it is required to download high quality media \
-            and to make full use of instaloader's features")
     else:
         print(f"No cookies found for Instagram in {browser}, Are you logged in succesfully in {browser}?")
 
@@ -113,6 +112,10 @@ def import_session(browser, instaloader, cookiefile):
         if not username:
             raise SystemExit(f"Not logged in. Are you logged in successfully in {browser}?")
         instaloader.context.username = username
+        print(f"{username} has been successfully logged in.")
+        next_step_text = (f"Next: Run instaloader --login={username} as it is required to download high quality media "
+            "and to make full use of instaloader's features.")
+        print(textwrap.fill(next_step_text, width=80))
 
 def _main(instaloader: Instaloader, targetlist: List[str],
           username: Optional[str] = None, password: Optional[str] = None,


### PR DESCRIPTION
Related issue: https://github.com/instaloader/instaloader/issues/1801
This fix avoid the simultaneous use of `--login` and `--load-cookies`.
This is necessary to avoid the conflict between username passed by the user and the logged in user account in a browser.

## Test cases

### Test case 1:

Testing instaloader with `--login` and `--load-cookies`
Expected result is to throw an error that says these two option cannot be used together.

Command Ran:
```console
python instaloader.py --login=its_juned42 --load-cookies=firefox
```

Observed output:
```
--load-cookies and --login cannot be used together.
```

### Test case 2:

Loading cookies by specifying a `--cookiefile`
This also works as expected.

Command Ran:
```console
python instaloader.py --load-cookies=firefox --cookiefile=C:\Users\juned_5f6qngh\AppData\Roaming\Mozilla\Firefox\Profiles\en1b55sk.default-release\cookies.sqlite
```

Observed output:
```
Cookies loaded successfully from firefox
Saved session to C:\Users\juned_5f6qngh\AppData\Local\Instaloader\session-its_juned42.
No targets were specified, thus nothing has been downloaded.
```

I deleted session file after this just to make sure it doesn't use it while I'm testing it.

### Test case 3:

Loading cookies normally by specifying a browser name.

Command Ran:
```console
python instaloader.py --load-cookies=firefox
```

Observed output:
```
Cookies loaded successfully from firefox
Saved session to C:\Users\juned_5f6qngh\AppData\Local\Instaloader\session-its_juned42.
No targets were specified, thus nothing has been downloaded.
```

- The completeness of this change
  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? No, not needed
  - Do you consider it ready to be merged or is it a draft? Yes
  - Can we help you at some point? Not at the moment
