### PR TITLE
Fix 403 during login due to incorrect login endpoint and CSRF token location

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -3,7 +3,6 @@ import json
 import os
 import pickle
 import random
-import re
 import shutil
 import sys
 import textwrap
@@ -260,7 +259,7 @@ class InstaloaderContext:
         self.do_sleep()
         # Make a request to Instagram's root URL, which will set the session's csrftoken cookie
         # Not using self.get_json() here, because we need to access the cookie
-        csrf_request = session.get('https://www.instagram.com/')
+        session.get('https://www.instagram.com/')
         # Add session's csrftoken cookie to session headers
         csrf_token = session.cookies.get_dict()['csrftoken']
         session.headers.update({'X-CSRFToken': csrf_token})

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -272,7 +272,6 @@ class InstaloaderContext:
         login = session.post('https://www.instagram.com/api/v1/web/accounts/login/ajax/',
                              data={'enc_password': enc_password, 'username': user}, allow_redirects=True)
         try:
-            print(login.text)
             resp_json = login.json()
 
         except json.decoder.JSONDecodeError as err:

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -410,16 +410,6 @@ class InstaloaderContext:
                 raise TooManyRequestsException("429 Too Many Requests")
             if resp.status_code != 200:
                 raise ConnectionException("HTTP error code {}.".format(resp.status_code))
-            is_html_query = not is_graphql_query and not "__a" in params and host == "www.instagram.com"
-            if is_html_query:
-                # Extract JSON from HTML response
-                match = re.search('(?<={"raw":").*?(?<!\\\\)(?=")', resp.text)
-                if match is None:
-                    raise QueryReturnedNotFoundException("Could not find JSON data in html response.")
-                # Unescape escaped JSON string
-                unescaped_string = match.group(0).encode("utf-8").decode("unicode_escape")
-                resp_json = json.loads(unescaped_string)
-                return resp_json
             else:
                 resp_json = resp.json()
             if 'status' in resp_json and resp_json['status'] != "ok":


### PR DESCRIPTION
Instagram made some changes on their end that resulted in an error when logging in.

```
Fatal error: Login error: JSON decode fail, 403 - Forbidden.
```

This is caused by instaloader using the wrong endpoint (`/accounts/login/ajax/` instead of `/api/v1/web/accounts/login/ajax/`). Additionally, the way instaloader gets the CSRF token (from the JSON returned by `/accounts/login/`) no longer works and throws another error.

```
Fatal error: Login error: "fail" status, message "CSRF token missing or incorrect".
```

This PR fixes both errors and makes login work again. It also removes the `is_html_query` part of `instaloadercontext.get_json`, which was only used for login and is no longer necessary.

Fixes #2126.