### PR TITLE
Change pinned post detection, fixes #2142

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -991,7 +991,8 @@ class Instaloader:
                             max_count: Optional[int] = None,
                             total_count: Optional[int] = None,
                             owner_profile: Optional[Profile] = None,
-                            takewhile: Optional[Callable[[Post], bool]] = None) -> None:
+                            takewhile: Optional[Callable[[Post], bool]] = None,
+                            possibly_pinned: int = 0) -> None:
         """
         Download the Posts returned by given Post Iterator.
 
@@ -1003,6 +1004,9 @@ class Instaloader:
         .. versionchanged:: 4.8
            Add `takewhile` parameter.
 
+        .. versionchanged:: 4.10.3
+           Add `possibly_pinned` parameter.
+
         :param posts: Post Iterator to loop through.
         :param target: Target name.
         :param fast_update: :option:`--fast-update`.
@@ -1011,6 +1015,8 @@ class Instaloader:
         :param total_count: Total number of posts returned by given iterator.
         :param owner_profile: Associated profile, if any.
         :param takewhile: Expression evaluated for each post. Once it returns false, downloading stops.
+        :param possibly_pinned: Number of posts that might be pinned. These posts do not cause download
+               to stop even if they've already been downloaded.
         """
         displayed_count = (max_count if total_count is None or max_count is not None and max_count < total_count
                            else total_count)
@@ -1032,7 +1038,7 @@ class Instaloader:
         ) as (is_resuming, start_index):
             for number, post in enumerate(posts, start=start_index + 1):
                 should_stop = not takewhile(post)
-                if should_stop and number <= 5:
+                if should_stop and number <= possibly_pinned:
                     continue
                 if (max_count is not None and number > max_count) or should_stop:
                     break
@@ -1066,7 +1072,7 @@ class Instaloader:
                         except PostChangedException:
                             post_changed = True
                             continue
-                    if fast_update and not downloaded and not post_changed and number > 5:
+                    if fast_update and not downloaded and not post_changed and number > possibly_pinned:
                         # disengage fast_update for first post when resuming
                         if not is_resuming or number > 0:
                             break
@@ -1488,7 +1494,7 @@ class Instaloader:
                     posts_to_download = profile.get_posts()
                     self.posts_download_loop(posts_to_download, profile_name, fast_update, post_filter,
                                              total_count=profile.mediacount, owner_profile=profile,
-                                             takewhile=posts_takewhile)
+                                             takewhile=posts_takewhile, possibly_pinned=3)
                     if latest_stamps is not None and posts_to_download.first_item is not None:
                         latest_stamps.set_last_post_timestamp(profile_name,
                                                               posts_to_download.first_item.date_local)

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1032,7 +1032,7 @@ class Instaloader:
         ) as (is_resuming, start_index):
             for number, post in enumerate(posts, start=start_index + 1):
                 should_stop = not takewhile(post)
-                if should_stop and start_index < 5:
+                if should_stop and number <= 5:
                     continue
                 if (max_count is not None and number > max_count) or should_stop:
                     break
@@ -1066,7 +1066,7 @@ class Instaloader:
                         except PostChangedException:
                             post_changed = True
                             continue
-                    if fast_update and not downloaded and not post_changed and not start_index < 5:
+                    if fast_update and not downloaded and not post_changed and number > 5:
                         # disengage fast_update for first post when resuming
                         if not is_resuming or number > 0:
                             break

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1032,7 +1032,7 @@ class Instaloader:
         ) as (is_resuming, start_index):
             for number, post in enumerate(posts, start=start_index + 1):
                 should_stop = not takewhile(post)
-                if should_stop and post.is_pinned:
+                if should_stop and start_index < 5:
                     continue
                 if (max_count is not None and number > max_count) or should_stop:
                     break
@@ -1066,7 +1066,7 @@ class Instaloader:
                         except PostChangedException:
                             post_changed = True
                             continue
-                    if fast_update and not downloaded and not post_changed and not post.is_pinned:
+                    if fast_update and not downloaded and not post_changed and not start_index < 5:
                         # disengage fast_update for first post when resuming
                         if not is_resuming or number > 0:
                             break

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -678,7 +678,11 @@ class Post:
 
     @property
     def is_pinned(self) -> bool:
-        """True if this Post has been pinned by at least one user.
+        """
+        .. deprecated: 4.10.3
+           This information is not returned by IG anymore
+
+        Used to return True if this Post has been pinned by at least one user, now likely returns always false.
 
         .. versionadded: 4.9.2"""
         return 'pinned_for_users' in self._node and bool(self._node['pinned_for_users'])


### PR DESCRIPTION
Fixes #2142.

The property that indicated whether a post is pinned is not available anymore. As a workaround, the first five posts are treated differently (as pinned posts were): if they were already downloaded, they are skipped, but they do not cause the iteration to stop.


*  - Is it just a proof of concept?* No
*  - Is the documentation updated (if appropriate)?* Yes
*  - Do you consider it ready to be merged or is it a draft?* Ready
*  - Can we help you at some point?* I'm open to suggestion for improvement
