### PR TITLE
sys.exit(1) on abnormal termination

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -230,8 +230,10 @@ def _main(instaloader: Instaloader, targetlist: List[str],
                                                    latest_stamps=latest_stamps)
     except KeyboardInterrupt:
         print("\nInterrupted by user.", file=sys.stderr)
+        sys.exit(1)
     except AbortDownloadException as exc:
         print("\nDownload aborted: {}.".format(exc), file=sys.stderr)
+        sys.exit(1)
     # Save session if it is useful
     if instaloader.context.is_logged_in:
         instaloader.save_session_to_file(sessionfile)


### PR DESCRIPTION
Exit with 1 if there was an error or the user aborted the run.

Motivation: after the download finishes, my bash script separates the videos, images, and metadata into separate folders. However, I only want to do that when the download finished completely, not when it was aborted. 
