### PR TITLE
More Access to a JsonExportable's Metadata

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -24,7 +24,7 @@ from .lateststamps import LatestStamps
 from .nodeiterator import NodeIterator, resumable_iteration
 from .sectioniterator import SectionIterator
 from .structures import (Hashtag, Highlight, JsonExportable, Post, PostLocation, Profile, Story, StoryItem,
-                         load_structure_from_file, save_structure_to_file, PostSidecarNode, TitlePic)
+                         load_structure_from_file, save_structure_to_file, get_json_structure, PostSidecarNode, TitlePic)
 
 
 def _get_config_dir() -> str:
@@ -356,6 +356,10 @@ class Instaloader:
         self.context.write_raw(resp, filename)
         os.utime(filename, (datetime.now().timestamp(), mtime.timestamp()))
         return True
+    
+    def get_json_structure(self, structure: JsonExportable) -> dict:
+        """Returns a JSON structure of a structure."""
+        return get_json_structure(structure)
 
     def save_metadata_json(self, filename: str, structure: JsonExportable) -> None:
         """Saves metadata JSON file of a structure."""

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -24,7 +24,7 @@ from .lateststamps import LatestStamps
 from .nodeiterator import NodeIterator, resumable_iteration
 from .sectioniterator import SectionIterator
 from .structures import (Hashtag, Highlight, JsonExportable, Post, PostLocation, Profile, Story, StoryItem,
-                         load_structure_from_file, save_structure_to_file, get_json_structure, PostSidecarNode, TitlePic)
+                         load_structure_from_file, save_structure_to_file, PostSidecarNode, TitlePic)
 
 
 def _get_config_dir() -> str:
@@ -357,9 +357,11 @@ class Instaloader:
         os.utime(filename, (datetime.now().timestamp(), mtime.timestamp()))
         return True
     
-    def get_json_structure(self, structure: JsonExportable) -> dict:
+    def get_post_json_structure(self, structure: Post) -> dict:
         """Returns a JSON structure of a structure."""
-        return get_json_structure(structure)
+        structure._obtain_iphone_struct()
+        structure._obtain_metadata()
+        return structure._asdict()
 
     def save_metadata_json(self, filename: str, structure: JsonExportable) -> None:
         """Saves metadata JSON file of a structure."""

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -246,6 +246,15 @@ class Post:
             if self.shortcode != self._full_metadata_dict['shortcode']:
                 self._node.update(self._full_metadata_dict)
                 raise PostChangedException
+            
+    def _obtain_iphone_struct(self) -> Dict[str, Any]:
+        if not self._context.iphone_support:
+            raise IPhoneSupportDisabledException("iPhone support is disabled.")
+        if not self._context.is_logged_in:
+            raise LoginRequiredException("--login required to access iPhone media info endpoint.")
+        if not self._iphone_struct_:
+            data = self._context.get_iphone_json(path='api/v1/media/{}/info/'.format(self.mediaid), params={})
+            self._iphone_struct_ = data['items'][0]
 
     @property
     def _full_metadata(self) -> Dict[str, Any]:


### PR DESCRIPTION
- A motivation for this change
  - Fixes the lack of access to post data that is only accessable through the instagram-private-api (e.g. saved_collection_ids).
  - added `get_json_structure(structure: JsonExportable)` function to be an attribute of an `Instaloader` instance. This allows for the access of post data that is not directly accessible through the Instaloader API (e.g. saved_collection_ids).

- The completeness of this change
  - Is it just a proof of concept? `No`
  - Is the documentation updated (if appropriate)? `No`
  - Do you consider it ready to be merged or is it a draft? `Read to be merged`
  - Can we help you at some point? `Sure!`