### PR TITLE
import lzma only when needed

### DIFF
--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -4,7 +4,6 @@ import json
 import os
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from lzma import LZMAError
 from typing import Any, Callable, Dict, Iterable, Iterator, NamedTuple, Optional, Tuple, TypeVar
 
 from .exceptions import AbortDownloadException, InvalidArgumentException, QueryReturnedBadRequestException
@@ -283,6 +282,7 @@ def resumable_iteration(context: InstaloaderContext,
     resume_file_path = format_path(iterator.magic)
     resume_file_exists = os.path.isfile(resume_file_path)
     if resume_file_exists:
+        from lzma import LZMAError
         try:
             fni = load(context, resume_file_path)
             if not isinstance(fni, FrozenNodeIterator):

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1,5 +1,4 @@
 import json
-import lzma
 import re
 from base64 import b64decode, b64encode
 from contextlib import suppress
@@ -2053,6 +2052,7 @@ def save_structure_to_file(structure: JsonExportable, filename: str) -> None:
     json_structure = get_json_structure(structure)
     compress = filename.endswith('.xz')
     if compress:
+        import lzma
         with lzma.open(filename, 'wt', check=lzma.CHECK_NONE) as fp:
             json.dump(json_structure, fp=fp, separators=(',', ':'))
     else:
@@ -2099,6 +2099,7 @@ def load_structure_from_file(context: InstaloaderContext, filename: str) -> Json
     """
     compressed = filename.endswith('.xz')
     if compressed:
+        import lzma
         fp = lzma.open(filename, 'rt')
     else:
         # pylint:disable=consider-using-with


### PR DESCRIPTION
I am running python3.12 on ubuntu without lzma included.

It's fine for me not to use compression, but I will hit an import error for lzma -> thus this PR.

Thanks