### PR TITLE
add login required message when getting comments

### DIFF
--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -67,7 +67,7 @@ What to Download of each Post
 
    Download and update comments for each post. This requires an additional
    request to the Instagram server for each post, which is why it is disabled by
-   default.
+   default. Requires :option:`--login`.
 
 .. option:: --no-captions
 

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -367,7 +367,7 @@ def main():
     g_post.add_argument('-C', '--comments', action='store_true',
                         help='Download and update comments for each post. '
                              'This requires an additional request to the Instagram '
-                             'server for each post, which is why it is disabled by default.')
+                             'server for each post, which is why it is disabled by default. Requires --login.')
     g_post.add_argument('--no-captions', action='store_true',
                         help='Do not create txt files.')
     g_post.add_argument('--post-metadata-txt', action='append',

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -685,6 +685,9 @@ class Post:
         .. versionchanged:: 4.7
            Change return type to ``Iterable``.
         """
+        if not self._context.is_logged_in:
+            raise LoginRequiredException("--login required to access comments of a post.")
+
         def _postcommentanswer(node):
             return PostCommentAnswer(id=int(node['id']),
                                      created_at_utc=datetime.utcfromtimestamp(node['created_at']),


### PR DESCRIPTION
Title: Add login required message when retrieving comments

Fixes #2230  #2234 

This change addresses the issue where Instagram now requires login to access comments on posts. By adding a message indicating the need for login, users will be informed about the requirement and can take appropriate action.

The proposed change adds a conditional check to `get_comments` method in the code. If the user is not logged in, it raises a `LoginRequiredException` with a message indicating the necessity of logging in to access comments.
