### PR TITLE
Use different exit codes for different failures

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -341,7 +341,7 @@ Different exit codes are used to indicate different kinds of error:
 4
   Fatal download error. Downloads were interrupted and no further
   attempts were made. Happens when a response with one of the status
-  codes in the :option:`abort-on` option were passed, or when
+  codes in the :option:`--abort-on` option were passed, or when
   Instagram logs the user out during downloads.
 
 5

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -314,6 +314,40 @@ when they were downloaded::
 
    instaloader --post-metadata-txt="{likes} likes, {comments} comments." <target>/*.json.xz
 
+.. _exit_codes:
+
+Exit codes
+^^^^^^^^^^
+
+Different exit codes are used to indicate different kinds of error:
+
+0
+  No error, all downloads were successful.
+
+1
+  A non-fatal error happened. One or more posts, or even one or more
+  profiles could not be downloaded, but execution was not stopped. The
+  errors are repeated at the end of the log for easy access.
+
+2
+  Command-line error. An unrecognized option was passed, or an invalid
+  combination of options, for example. No interaction with Instagram
+  was made.
+
+3
+  Login error. It was not possible to login. Downloads were not
+  attempted.
+
+4
+  Fatal download error. Downloads were interrupted and no further
+  attempts were made. Happens when a response with one of the status
+  codes in the :option:`abort-on` option were passed, or when
+  Instagram logs the user out during downloads.
+
+5
+  Interrupted by the user. Happens when the user presses Control-C or
+  sends SIGINT to the process.
+
 .. _instaloader-as-cronjob:
 
 Instaloader as Cronjob

--- a/docs/module/exceptions.rst
+++ b/docs/module/exceptions.rst
@@ -27,15 +27,25 @@ Exceptions
 
 .. autoexception:: LoginRequiredException
 
+.. autoexception:: LoginException
+
+   .. versionadded:: 4.12
+
 .. autoexception:: TwoFactorAuthRequiredException
 
    .. versionadded:: 4.2
+
+   .. versionchanged:: 4.12
+      Inherits LoginException
 
 .. autoexception:: InvalidArgumentException
 
 .. autoexception:: BadResponseException
 
 .. autoexception:: BadCredentialsException
+
+   .. versionchanged:: 4.12
+      Inherits LoginException
 
 .. autoexception:: PostChangedException
 

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -320,7 +320,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
         else:
             # Instaloader did not do anything
             instaloader.context.log("usage:" + usage_string())
-        exit_code = ExitCode.NON_FATAL_ERROR
+            exit_code = ExitCode.INIT_FAILURE
     return exit_code
 
 

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -11,7 +11,7 @@ from enum import IntEnum
 from typing import List, Optional
 
 from . import (AbortDownloadException, BadCredentialsException, Instaloader, InstaloaderException,
-               InvalidArgumentException, Post, Profile, ProfileNotExistsException, StoryItem,
+               InvalidArgumentException, LoginException, Post, Profile, ProfileNotExistsException, StoryItem,
                TwoFactorAuthRequiredException, __version__, load_structure_from_file)
 from .instaloader import (get_default_session_filename, get_default_stamps_filename)
 from .instaloadercontext import default_user_agent
@@ -106,7 +106,7 @@ def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
     if cookies:
         print(f"Cookies loaded successfully from {browser}")
     else:
-        print(f"No cookies found for Instagram in {browser}, Are you logged in succesfully in {browser}?")
+        raise LoginException(f"No cookies found for Instagram in {browser}, Are you logged in succesfully in {browser}?")
 
     if cookie_name:
         return cookies.get(cookie_name, {})
@@ -120,7 +120,7 @@ def import_session(browser, instaloader, cookiefile):
         instaloader.context.update_cookies(cookie)
         username = instaloader.test_login()
         if not username:
-            raise SystemExit(f"Not logged in. Are you logged in successfully in {browser}?")
+            raise LoginException(f"Not logged in. Are you logged in successfully in {browser}?")
         instaloader.context.username = username
         print(f"{username} has been successfully logged in.")
         next_step_text = (f"Next: Run instaloader --login={username} as it is required to download high quality media "
@@ -568,6 +568,9 @@ def main():
     except InvalidArgumentException as err:
         print(err, file=sys.stderr)
         raise SystemExit(ErrorCodes.INIT_FAILURE)
+    except LoginException as err:
+        print(err, file=sys.stderr)
+        raise SystemExit(ErrorCodes.LOGIN_FAILURE)
     except InstaloaderException as err:
         print("Fatal error: %s" % err)
         raise SystemExit(ErrorCodes.UNEXPECTED_ERROR)

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -25,7 +25,7 @@ except ImportError:
 
 class ExitCodes(IntEnum):
     SUCESS = 0
-    DOWNLOAD_FAILURE = 1
+    NON_FATAL_ERROR = 1
     INIT_FAILURE = 2
     LOGIN_FAILURE = 3
     DOWNLOAD_ABORTED = 4
@@ -571,6 +571,8 @@ def main():
                           browser=args.load_cookies,
                           cookiefile=args.cookiefile)
         loader.close()
+        if loader.has_stored_errors():
+            exit_code = ExitCodes.NON_FATAL_ERROR
     except InvalidArgumentException as err:
         print(err, file=sys.stderr)
         exit_code = ExitCodes.INIT_FAILURE

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -23,8 +23,8 @@ except ImportError:
     bc3_library = False
 
 
-class ExitCodes(IntEnum):
-    SUCESS = 0
+class ExitCode(IntEnum):
+    SUCCESS = 0
     NON_FATAL_ERROR = 1
     INIT_FAILURE = 2
     LOGIN_FAILURE = 3
@@ -143,7 +143,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
           max_count: Optional[int] = None, post_filter_str: Optional[str] = None,
           storyitem_filter_str: Optional[str] = None,
           browser: Optional[str] = None,
-          cookiefile: Optional[str] = None) -> int:
+          cookiefile: Optional[str] = None) -> ExitCode:
     """Download set of profiles, hashtags etc. and handle logging in and session files if desired."""
     # Parse and generate filter function
     post_filter = None
@@ -199,7 +199,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
     # Try block for KeyboardInterrupt (save session on ^C)
     profiles = set()
     anonymous_retry_profiles = set()
-    exit_code = ExitCodes.SUCESS
+    exit_code = ExitCode.SUCCESS
     try:
         # Generate set of profiles, already downloading non-profile targets
         for target in targetlist:
@@ -305,10 +305,10 @@ def _main(instaloader: Instaloader, targetlist: List[str],
                                                    latest_stamps=latest_stamps)
     except KeyboardInterrupt:
         print("\nInterrupted by user.", file=sys.stderr)
-        exit_code = ExitCodes.USER_ABORTED
+        exit_code = ExitCode.USER_ABORTED
     except AbortDownloadException as exc:
         print("\nDownload aborted: {}.".format(exc), file=sys.stderr)
-        exit_code = ExitCodes.DOWNLOAD_ABORTED
+        exit_code = ExitCode.DOWNLOAD_ABORTED
     # Save session if it is useful
     if instaloader.context.is_logged_in:
         instaloader.save_session_to_file(sessionfile)
@@ -320,7 +320,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
         else:
             # Instaloader did not do anything
             instaloader.context.log("usage:" + usage_string())
-        exit_code = ExitCodes.NON_FATAL_ERROR
+        exit_code = ExitCode.NON_FATAL_ERROR
     return exit_code
 
 
@@ -572,17 +572,17 @@ def main():
                           browser=args.load_cookies,
                           cookiefile=args.cookiefile)
         loader.close()
-        if loader.has_stored_errors():
-            exit_code = ExitCodes.NON_FATAL_ERROR
+        if loader.has_stored_errors:
+            exit_code = ExitCode.NON_FATAL_ERROR
     except InvalidArgumentException as err:
         print(err, file=sys.stderr)
-        exit_code = ExitCodes.INIT_FAILURE
+        exit_code = ExitCode.INIT_FAILURE
     except LoginException as err:
         print(err, file=sys.stderr)
-        exit_code = ExitCodes.LOGIN_FAILURE
+        exit_code = ExitCode.LOGIN_FAILURE
     except InstaloaderException as err:
         print("Fatal error: %s" % err)
-        exit_code = ExitCodes.UNEXPECTED_ERROR
+        exit_code = ExitCode.UNEXPECTED_ERROR
     sys.exit(exit_code)
 
 

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -106,7 +106,8 @@ def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
     if cookies:
         print(f"Cookies loaded successfully from {browser}")
     else:
-        raise LoginException(f"No cookies found for Instagram in {browser}, Are you logged in succesfully in {browser}?")
+        raise LoginException(f"No cookies found for Instagram in {browser}, "
+                             f"Are you logged in succesfully in {browser}?")
 
     if cookie_name:
         return cookies.get(cookie_name, {})
@@ -567,13 +568,13 @@ def main():
         loader.close()
     except InvalidArgumentException as err:
         print(err, file=sys.stderr)
-        raise SystemExit(ErrorCodes.INIT_FAILURE)
+        sys.exit(ErrorCodes.INIT_FAILURE)
     except LoginException as err:
         print(err, file=sys.stderr)
-        raise SystemExit(ErrorCodes.LOGIN_FAILURE)
+        sys.exit(ErrorCodes.LOGIN_FAILURE)
     except InstaloaderException as err:
         print("Fatal error: %s" % err)
-        raise SystemExit(ErrorCodes.UNEXPECTED_ERROR)
+        sys.exit(ErrorCodes.UNEXPECTED_ERROR)
 
 
 if __name__ == "__main__":

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -320,6 +320,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
         else:
             # Instaloader did not do anything
             instaloader.context.log("usage:" + usage_string())
+        exit_code = ExitCodes.NON_FATAL_ERROR
     return exit_code
 
 

--- a/instaloader/exceptions.py
+++ b/instaloader/exceptions.py
@@ -33,7 +33,11 @@ class LoginRequiredException(InstaloaderException):
     pass
 
 
-class TwoFactorAuthRequiredException(InstaloaderException):
+class LoginException(InstaloaderException):
+    pass
+
+
+class TwoFactorAuthRequiredException(LoginException):
     pass
 
 
@@ -45,7 +49,7 @@ class BadResponseException(InstaloaderException):
     pass
 
 
-class BadCredentialsException(InstaloaderException):
+class BadCredentialsException(LoginException):
     pass
 
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -643,11 +643,16 @@ class Instaloader:
     def login(self, user: str, passwd: str) -> None:
         """Log in to instagram with given username and password and internally store session object.
 
-        :raises InvalidArgumentException: If the provided username does not exist.
         :raises BadCredentialsException: If the provided password is wrong.
-        :raises ConnectionException: If connection to Instagram failed.
         :raises TwoFactorAuthRequiredException: First step of 2FA login done, now call
-           :meth:`Instaloader.two_factor_login`."""
+           :meth:`Instaloader.two_factor_login`.
+        :raises LoginException: An error happened during login (for example, and invalid response).
+           Or if the provided username does not exist.
+
+        .. versionchanged:: 4.12
+           Raises LoginException instead of ConnectionException when an error happens.
+           Raises LoginException instead of InvalidArgumentException when the username does not exist.
+        """
         self.context.login(user, passwd)
 
     def two_factor_login(self, two_factor_code) -> None:
@@ -1582,11 +1587,16 @@ class Instaloader:
     def interactive_login(self, username: str) -> None:
         """Logs in and internally stores session, asking user for password interactively.
 
-        :raises LoginRequiredException: when in quiet mode.
-        :raises InvalidArgumentException: If the provided username does not exist.
-        :raises ConnectionException: If connection to Instagram failed."""
+        :raises InvalidArgumentException: when in quiet mode.
+        :raises LoginException: If the provided username does not exist.
+        :raises ConnectionException: If connection to Instagram failed.
+
+        .. versionchanged:: 4.12
+           Raises InvalidArgumentException instead of LoginRequiredException when in quiet mode.
+           Raises LoginException instead of InvalidArgumentException when the username does not exist.
+        """
         if self.context.quiet:
-            raise LoginRequiredException("Quiet mode requires given password or valid session file.")
+            raise InvalidArgumentException("Quiet mode requires given password or valid session file.")
         try:
             password = None
             while password is None:

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1615,3 +1615,9 @@ class Instaloader:
                 except BadCredentialsException as err:
                     print(err, file=sys.stderr)
                     pass
+
+    def has_stored_errors(self) -> bool:
+        """Returns whether any error has been reported and stored to be repeated at program termination.
+
+        .. versionadded: 4.12"""
+        return self.context.has_stored_errors()

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -646,7 +646,7 @@ class Instaloader:
         :raises BadCredentialsException: If the provided password is wrong.
         :raises TwoFactorAuthRequiredException: First step of 2FA login done, now call
            :meth:`Instaloader.two_factor_login`.
-        :raises LoginException: An error happened during login (for example, and invalid response).
+        :raises LoginException: An error happened during login (for example, an invalid response was received).
            Or if the provided username does not exist.
 
         .. versionchanged:: 4.12
@@ -1616,8 +1616,9 @@ class Instaloader:
                     print(err, file=sys.stderr)
                     pass
 
+    @property
     def has_stored_errors(self) -> bool:
         """Returns whether any error has been reported and stored to be repeated at program termination.
 
         .. versionadded: 4.12"""
-        return self.context.has_stored_errors()
+        return self.context.has_stored_errors

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -151,6 +151,7 @@ class InstaloaderContext:
         if repeat_at_end:
             self.error_log.append(msg)
 
+    @property
     def has_stored_errors(self) -> bool:
         """Returns whether any error has been reported and stored to be repeated at program termination.
 

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -151,6 +151,12 @@ class InstaloaderContext:
         if repeat_at_end:
             self.error_log.append(msg)
 
+    def has_stored_errors(self) -> bool:
+        """Returns whether any error has been reported and stored to be repeated at program termination.
+
+        .. versionadded: 4.12"""
+        return bool(self.error_log)
+
     def close(self):
         """Print error log and close session"""
         if self.error_log and not self.quiet:


### PR DESCRIPTION
Fixes #2220 

- [X] Initialization errors
- [X] Login errors
- [x] Non-fatal error while downloading
- [x] --abort-on
- [x] SIGINT / Control-C
- [x] Documentation

Here's the general idea of how each situation is handled:
* Non fatal error (1): Before exiting, it is checked if something was logged to be repeated at the end (those are the real warning/erros that require attention). If so, the exit code is 1.
* Initialization failure (2): returned by argparse for invalid options and other parsing errors; other errors that instaloader itself detects raise `InvalidArgumentException`, which is caught at `main()`.
  - `InvalidArgumentException` is also used for other errors, that generally can only be triggered when used as a module. I don't think that's a problem, but another exception could be used specifically for those initialization errors.
* Login failure (3): raises the new `LoginException`. Some more specific login exceptions were made into subclasses.
* Download aborted (4) and user aborted (5): these were already caught at `_main`, it just sets a flag with the status to be returned.

Some notes:
* I created a new exit code 99 for any uncaught InstaloaderException (at the very end of `__main__.py`). But maybe that `except` is not necessary: hopefully no exception should reach there, and if it does, maybe letting the program crash (and include the stack trace) is more appropriate.
* I've made the failure when no IG cookies are found an actual failure. It used to just print a message and carry on (anonymously)
* When nothing is done (no targets are specified), I'm returning non-fatal error, but initialization failure could also be appropriate, especially when the user was not logged in. But having two different status codes for two very similar situations is probably too confusing, so I used non-fatal error for both cases.