### PR TITLE
Add support for more browsers

### DIFF
--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -202,7 +202,7 @@ Instaloader to login.
    This feature requires the browser_cookie3 library.
    Compatible with :option:`--cookiefile` if you want to load cookies from browser profiles.
    Incompatible with :option:`--login` due to potential username mismatch between user input and browser login.
-   Supported browsers: Chrome, Chromium, Firefox, Edge, Brave, Opera, Opera GX, Safari, Vivaldi and Librewolf.
+   Supported browsers: Brave, Chrome, Chromium, Edge, Firefox, LibreWolf, Opera, Opera_GX, Safari and Vivaldi.
 
    After loading the cookies run the :option:`--login` option as it is required to download high quality media
    and to make full use of Instaloader's features.

--- a/docs/cli-options.rst
+++ b/docs/cli-options.rst
@@ -202,7 +202,7 @@ Instaloader to login.
    This feature requires the browser_cookie3 library.
    Compatible with :option:`--cookiefile` if you want to load cookies from browser profiles.
    Incompatible with :option:`--login` due to potential username mismatch between user input and browser login.
-   Supported browsers: Chrome, Firefox, Edge, Opera, Safari, Brave.
+   Supported browsers: Chrome, Chromium, Firefox, Edge, Brave, Opera, Opera GX, Safari, Vivaldi and Librewolf.
 
    After loading the cookies run the :option:`--login` option as it is required to download high quality media
    and to make full use of Instaloader's features.

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -85,22 +85,22 @@ def filterstr_to_filterfunc(filter_str: str, item_type: type):
 
 def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
     supported_browsers = {
+        "brave": browser_cookie3.brave,
         "chrome": browser_cookie3.chrome,
         "chromium": browser_cookie3.chromium,
-        "firefox": browser_cookie3.firefox,
         "edge": browser_cookie3.edge,
-        "brave": browser_cookie3.brave,
+        "firefox": browser_cookie3.firefox,
+        "librewolf": browser_cookie3.librewolf,
         "opera": browser_cookie3.opera,
         "opera_gx": browser_cookie3.opera_gx,
         "safari": browser_cookie3.safari,
         "vivaldi": browser_cookie3.vivaldi,
-        "librewolf": browser_cookie3.librewolf,
     }
 
     if browser not in supported_browsers:
         raise InvalidArgumentException("Loading cookies from the specified browser failed\n"
-                                       "Supported browsers are Chrome, Chromium, Firefox, Edge, "
-                                       "Brave, Opera, Opera GX, Safari, Vivaldi and Librewolf")
+                                       "Supported browsers are Brave, Chrome, Chromium, Edge, Firefox, LibreWolf, "
+                                       "Opera, Opera_GX, Safari and Vivaldi")
 
     cookies = {}
     browser_cookies = list(supported_browsers[browser](cookie_file=cookie_file))

--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -86,16 +86,21 @@ def filterstr_to_filterfunc(filter_str: str, item_type: type):
 def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
     supported_browsers = {
         "chrome": browser_cookie3.chrome,
+        "chromium": browser_cookie3.chromium,
         "firefox": browser_cookie3.firefox,
         "edge": browser_cookie3.edge,
         "brave": browser_cookie3.brave,
         "opera": browser_cookie3.opera,
-        "safari": browser_cookie3.safari
+        "opera_gx": browser_cookie3.opera_gx,
+        "safari": browser_cookie3.safari,
+        "vivaldi": browser_cookie3.vivaldi,
+        "librewolf": browser_cookie3.librewolf,
     }
 
     if browser not in supported_browsers:
         raise InvalidArgumentException("Loading cookies from the specified browser failed\n"
-                                       "Supported browsers are Chrome, Firefox, Edge, Brave, Opera and Safari")
+                                       "Supported browsers are Chrome, Chromium, Firefox, Edge, "
+                                       "Brave, Opera, Opera GX, Safari, Vivaldi and Librewolf")
 
     cookies = {}
     browser_cookies = list(supported_browsers[browser](cookie_file=cookie_file))


### PR DESCRIPTION
Fixes #2241.

Also adds other browsers that the library supports but were not included in instaloader.

I don't have Vivaldi or those browsers so I haven't actually tested that the cookies are loaded, but this would be a test more of the library than instaloader itself, since all the work is done by the library.

  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? Yes
  - Do you consider it ready to be merged or is it a draft? Should be ready
  - Can we help you at some point?  It's a simple change and should be ready, but I'm open to any comments
