### PR TITLE
Update actions versions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Instaloader Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # needed for building docs
       - name: "Setup Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
       - name: "Install Dependencies"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: 'pip'
       - name: "Install Dependencies"
         run: |
           python -m pip install pipenv==2023.12.1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-          cache: 'pip'
+          cache: 'pipenv'
       - name: "Install Dependencies"
         run: |
           python -m pip install pipenv==2023.12.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout Instaloader Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: 'pipenv'
       - name: Install Dependencies
         run: |
           python -m pip install pipenv==2023.12.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Dependencies
         run: |
           python -m pip install pipenv==2023.12.1

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: 'pip'
       - name: "Get the tagged version"
         id: get_version
         env:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Setup Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
       - name: "Get the tagged version"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-          cache: 'pip'
       - name: "Get the tagged version"
         id: get_version
         env:

--- a/.github/workflows/windows_exe.yml
+++ b/.github/workflows/windows_exe.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Instaloader repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           architecture: x64

--- a/.github/workflows/windows_exe.yml
+++ b/.github/workflows/windows_exe.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
           architecture: x64
       - name: Get the tagged version
         id: get_version

--- a/.github/workflows/windows_exe.yml
+++ b/.github/workflows/windows_exe.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: 'pip'
+          cache: 'pipenv'
           architecture: x64
       - name: Get the tagged version
         id: get_version


### PR DESCRIPTION
Fix GitHub Actions Node.js deprecation warnings

`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v2.`

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v2.`

This PR bumps actions/checkout to v4, and actions/setup-python to v5.