### PR TITLE
Replace deprecated 'set-output' command

### DIFF
--- a/.github/workflows/windows_exe.yml
+++ b/.github/workflows/windows_exe.yml
@@ -18,7 +18,7 @@ jobs:
         id: get_version
         env:
           GITHUB_REF: ${{ github.ref }}
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
         shell: bash
       - name: Run custom python script for EXE creation
         env:


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR fixes the deprecation warning by following the migration guide from the link above.