### PR TITLE
Detect errors when checking if the user is logged in

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -243,8 +243,12 @@ class InstaloaderContext:
 
     def test_login(self) -> Optional[str]:
         """Not meant to be used directly, use :meth:`Instaloader.test_login`."""
-        data = self.graphql_query("d6f4427fbe92d846298cf93df0b937d3", {})
-        return data["data"]["user"]["username"] if data["data"]["user"] is not None else None
+        try:
+            data = self.graphql_query("d6f4427fbe92d846298cf93df0b937d3", {})
+            return data["data"]["user"]["username"] if data["data"]["user"] is not None else None
+        except (AbortDownloadException, ConnectionException) as err:
+            self.error(f"Error when checking if logged in: {err}")
+            return None
 
     def login(self, user, passwd):
         """Not meant to be used directly, use :meth:`Instaloader.login`.


### PR DESCRIPTION
The first query after loading a session from cookies (done by `test_login()`) failed, and it was not caught, resulting in this stack trace:
```
Traceback (most recent call last):
  File "/home/ekalin/instagrams/instaloader/instaloader.py", line 6, in <module>
    main()
  File "/home/ekalin/instagrams/instaloader/instaloader/__main__.py", line 559, in main
    exit_code = _main(loader,
                ^^^^^^^^^^^^^
  File "/home/ekalin/instagrams/instaloader/instaloader/__main__.py", line 163, in _main
    import_session(browser.lower(), instaloader, cookiefile)
  File "/home/ekalin/instagrams/instaloader/instaloader/__main__.py", line 123, in import_session
    username = instaloader.test_login()
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ekalin/instagrams/instaloader/instaloader/instaloader.py", line 641, in test_login
    return self.context.test_login()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ekalin/instagrams/instaloader/instaloader/instaloadercontext.py", line 246, in test_login
    data = self.graphql_query("d6f4427fbe92d846298cf93df0b937d3", {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ekalin/instagrams/instaloader/instaloader/instaloadercontext.py", line 486, in graphql_query
    resp_json = self.get_json('graphql/query',
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ekalin/instagrams/instaloader/instaloader/instaloadercontext.py", line 398, in get_json
    raise AbortDownloadException("Query to https://{}/{} responded with \"{} {}\"{}{}".format(
instaloader.exceptions.AbortDownloadException: Query to https://www.instagram.com/graphql/query responded with "401 Unauthorized": {"message":"Please wait a few minutes before you try again.","require_login":true,"status":"fail"}
```

Since login processing (doesn't matter whether importing cookies, loading a saved session or trying to login) happens very early, it is not caught by the main try/except handler that handles `AbortDownloadException`. And it shouldn't, because an exception caused by a query failure at this point should result in the exit code for login failure, not the regular exit code for download aborted.

I was running with `--abort-on` so the failure caused an immediate abort, but without that option it should fail in a similar manner, but with a `ConnectionException` or one of its subclasses, possibly after some retries.

This change detects exceptions raised when there is a query error in `test_login()`, and makes this function return `None`, as if the query didn't fail, but the result was unexpected. This is turn raises a `LoginException` in the cookie import code, or resumes the normal login behavior otherwise.

  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? Not necessary
  - Do you consider it ready to be merged or is it a draft? Ready
  - Can we help you at some point? Not really necessary
