### PR TITLE
feat: adding max_count parameter to limit posts on download

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1427,7 +1427,7 @@ class Instaloader:
            Whether :exc:`LoginRequiredException` and :exc:`PrivateProfileNotFollowedException` should be raised or
            catched and printed with :meth:`InstaloaderContext.error_catcher`.
         :param latest_stamps: :option:`--latest-stamps`.
-        :param max_count: Maximum count of posts to download
+        :param max_count: Maximum count of posts to download.
 
         .. versionadded:: 4.1
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1409,7 +1409,8 @@ class Instaloader:
                           post_filter: Optional[Callable[[Post], bool]] = None,
                           storyitem_filter: Optional[Callable[[Post], bool]] = None,
                           raise_errors: bool = False,
-                          latest_stamps: Optional[LatestStamps] = None):
+                          latest_stamps: Optional[LatestStamps] = None,
+                          max_count: Optional[int] = None):
         """High-level method to download set of profiles.
 
         :param profiles: Set of profiles to download.
@@ -1434,6 +1435,9 @@ class Instaloader:
 
         .. versionchanged:: 4.8
            Add `latest_stamps` parameter.
+
+        .. versionchanged:: 4.12
+           Add `max_count` parameter.
         """
 
         @contextmanager
@@ -1499,7 +1503,7 @@ class Instaloader:
                     posts_to_download = profile.get_posts()
                     self.posts_download_loop(posts_to_download, profile_name, fast_update, post_filter,
                                              total_count=profile.mediacount, owner_profile=profile,
-                                             takewhile=posts_takewhile, possibly_pinned=3)
+                                             takewhile=posts_takewhile, possibly_pinned=3, max_count=max_count)
                     if latest_stamps is not None and posts_to_download.first_item is not None:
                         latest_stamps.set_last_post_timestamp(profile_name,
                                                               posts_to_download.first_item.date_local)

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1427,6 +1427,7 @@ class Instaloader:
            Whether :exc:`LoginRequiredException` and :exc:`PrivateProfileNotFollowedException` should be raised or
            catched and printed with :meth:`InstaloaderContext.error_catcher`.
         :param latest_stamps: :option:`--latest-stamps`.
+        :param max_count: Limiting number of post to download
 
         .. versionadded:: 4.1
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1427,7 +1427,7 @@ class Instaloader:
            Whether :exc:`LoginRequiredException` and :exc:`PrivateProfileNotFollowedException` should be raised or
            catched and printed with :meth:`InstaloaderContext.error_catcher`.
         :param latest_stamps: :option:`--latest-stamps`.
-        :param max_count: Limiting number of post to download
+        :param max_count: Maximum count of posts to download
 
         .. versionadded:: 4.1
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1437,7 +1437,7 @@ class Instaloader:
         .. versionchanged:: 4.8
            Add `latest_stamps` parameter.
 
-        .. versionchanged:: 4.12
+        .. versionchanged:: 4.13
            Add `max_count` parameter.
         """
 


### PR DESCRIPTION
### Motivation for this change
👋 Hi! I made this PR to make it possible to control the quantity of posts downloaded by profile.
The core method `self.posts_download_loop()` already has this functionality, but the external calling function `instaloader.download_profiles()` were not adjusted to receive or pass this argument further.

  - Fixes #2269. (I believe this change will solve this issue) 

### Changes proposed in this pull request
* Added parameter `max_count` to `download_profiles()` method

### The completeness of this change
  - Is it just a proof of concept? **No**
  - Is the documentation updated (if appropriate)? **Yes**
  - Do you consider it ready to be merged or is it a draft? **Ready** 
  - Can we help you at some point? **Feel free to give me some guidelines to better solve this problem, I am fully available to do so.**
