### PR TITLE
Fix Unicode Encode Error

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -140,7 +140,11 @@ class InstaloaderContext:
     def log(self, *msg, sep='', end='\n', flush=False):
         """Log a message to stdout that can be suppressed with --quiet."""
         if not self.quiet:
-            print(*msg, sep=sep, end=end, flush=flush)
+            try:
+                print(*msg, sep=sep, end=end, flush=flush)
+            except UnicodeEncodeError:
+                message = sep.join(str(m) for m in msg).encode('utf-8', errors='replace').decode('utf-8')
+                print(message, sep=sep, end=end, flush=flush, file=sys.stderr)
 
     def error(self, msg, repeat_at_end=True):
         """Log a non-fatal error message to stderr, which is repeated at program termination.


### PR DESCRIPTION
This fixes an error that occurs when downloading a Highlights Collection with an invalid emoji in the title

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Scripts\instaloader.exe\__main__.py", line 7, in <module>
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Lib\site-packages\instaloader\__main__.py", line 541, in main
    _main(loader,
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Lib\site-packages\instaloader\__main__.py", line 283, in _main
    instaloader.download_profiles(profiles,
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Lib\site-packages\instaloader\instaloader.py", line 1484, in download_profiles     
    self.download_highlights(profile, fast_update=fast_update, storyitem_filter=storyitem_filter)
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Lib\site-packages\instaloader\instaloader.py", line 81, in call
    return func(instaloader, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Lib\site-packages\instaloader\instaloader.py", line 970, in download_highlights    
    self.context.log("Retrieving highlights \"{}\" from profile {}".format(user_highlight.title, name))
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Lib\site-packages\instaloader\instaloadercontext.py", line 143, in log
    print(*msg, sep=sep, end=end, flush=flush)
  File "C:\Users\macielg1\AppData\Local\Programs\Python\Python312\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f3b9' in position 23: character maps to <undefined>
```

The updated code tries to print normally. If there's an error, it replaces the invalid characters.