### PR TITLE
Fix. Return profile_pic_url for non-iphone request

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1160,7 +1160,7 @@ class Profile:
         """Return URL of lower-quality profile picture.
 
         .. versionadded:: 4.9.3"""
-        return self._metadata("profile_pic_url_hd")
+        return self._metadata("profile_pic_url")
 
     def get_profile_pic_url(self) -> str:
         """.. deprecated:: 4.0.3


### PR DESCRIPTION
There is no profile_pic_url_hd in json response of web interface and no way to get TopSearchResults data in single request with profile picture links.
