### PR TITLE
Fix location endpoint URL

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -809,9 +809,12 @@ class Post:
             return None
         location_id = int(loc['id'])
         if any(k not in loc for k in ('name', 'slug', 'has_public_page', 'lat', 'lng')):
-            loc.update(self._context.get_iphone_json("api/v1/locations/web_info/,
-                                                params={'location_id': location_id, 'show_nearby': 'false', 'skip_recent_tab': 'false'}
-                                            )['native_location_data']['location_info'])
+            loc.update(self._context.get_iphone_json("api/v1/locations/web_info/",
+                                                params={
+                                                    'location_id': location_id, 
+                                                    'show_nearby': 'false', 
+                                                    'skip_recent_tab': 'false'
+                                                })['native_location_data']['location_info'])
         self._location = PostLocation(location_id, loc['name'], loc['slug'], loc['has_public_page'],
                                       loc.get('lat'), loc.get('lng'))
         return self._location

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -809,8 +809,9 @@ class Post:
             return None
         location_id = int(loc['id'])
         if any(k not in loc for k in ('name', 'slug', 'has_public_page', 'lat', 'lng')):
-            loc.update(self._context.get_json("explore/locations/{0}/".format(location_id),
-                                              params={'__a': 1, '__d': 'dis'})['native_location_data']['location_info'])
+            loc.update(self._context.get_json("api/v1/locations/web_info,
+                                                params={'location_id': location_id, 'show_nearby': 'false', 'skip_recent_tab': 'false'}
+                                            )['native_location_data']['location_info'])
         self._location = PostLocation(location_id, loc['name'], loc['slug'], loc['has_public_page'],
                                       loc.get('lat'), loc.get('lng'))
         return self._location

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -809,7 +809,7 @@ class Post:
             return None
         location_id = int(loc['id'])
         if any(k not in loc for k in ('name', 'slug', 'has_public_page', 'lat', 'lng')):
-            loc.update(self._context.get_json("api/v1/locations/web_info,
+            loc.update(self._context.get_iphone_json("api/v1/locations/web_info/,
                                                 params={'location_id': location_id, 'show_nearby': 'false', 'skip_recent_tab': 'false'}
                                             )['native_location_data']['location_info'])
         self._location = PostLocation(location_id, loc['name'], loc['slug'], loc['has_public_page'],


### PR DESCRIPTION
The motivation is to solve the problem that ive been received on get post location information. The endpoint apparently has been changed from `explore/locations/<location_id>` to `api/v1/locations/web_info` with the query string `location_id` and some others default.

So, I changed the endpoint and the params, just it.

- The completeness of this change
  - Is it just a proof of concept? Not.
  - Is the documentation updated (if appropriate)? Not.
  - Do you consider it ready to be merged or is it a draft? Yes, i think so, I'm using the version that i chaged locally.
  - Can we help you at some point? I don't think so
  
 Thank you very much!