### PR TITLE
add --reels (TERRIBLE SOLUTION)

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -140,6 +140,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
           download_highlights: bool = False,
           download_tagged: bool = False,
           download_igtv: bool = False,
+          download_reels: bool = False,
           fast_update: bool = False,
           latest_stamps_file: Optional[str] = None,
           max_count: Optional[int] = None, post_filter_str: Optional[str] = None,
@@ -299,7 +300,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
             instaloader.context.log("Hint: Login to download higher-quality versions of pictures.")
         instaloader.download_profiles(profiles,
                                       download_profile_pic, download_posts, download_tagged, download_igtv,
-                                      download_highlights, download_stories,
+                                      download_highlights, download_stories, download_reels, browser,
                                       fast_update, post_filter, storyitem_filter, latest_stamps=latest_stamps)
         if anonymous_retry_profiles:
             instaloader.context.log("Downloading anonymously: {}"
@@ -376,6 +377,8 @@ def main():
     g_post.add_argument('--no-pictures', action='store_true',
                         help='Do not download post pictures. Cannot be used together with --fast-update. '
                              'Implies --no-video-thumbnails, does not imply --no-videos.')
+    g_post.add_argument('--reels', action='store_true',
+                        help='Download reels of each profile that is downloaded.')
     g_post.add_argument('-V', '--no-videos', action='store_true',
                         help='Do not download videos.')
     g_post.add_argument('--no-video-thumbnails', action='store_true',
@@ -547,7 +550,9 @@ def main():
                              download_pictures=not args.no_pictures,
                              download_videos=not args.no_videos, download_video_thumbnails=not args.no_video_thumbnails,
                              download_geotags=args.geotags,
-                             download_comments=args.comments, save_metadata=not args.no_metadata_json,
+                             download_comments=args.comments, 
+                             download_reels=args.reels,
+                             save_metadata=not args.no_metadata_json,
                              compress_json=not args.no_compress_json,
                              post_metadata_txt_pattern=post_metadata_txt_pattern,
                              storyitem_metadata_txt_pattern=storyitem_metadata_txt_pattern,
@@ -571,6 +576,7 @@ def main():
                           download_highlights=args.highlights,
                           download_tagged=args.tagged,
                           download_igtv=args.igtv,
+                          download_reels=args.reels,
                           fast_update=args.fast_update,
                           latest_stamps_file=args.latest_stamps,
                           max_count=int(args.count) if args.count is not None else None,

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -219,6 +219,7 @@ class Instaloader:
                  download_video_thumbnails: bool = True,
                  download_geotags: bool = False,
                  download_comments: bool = False,
+                 download_reels: bool = False,
                  save_metadata: bool = True,
                  compress_json: bool = True,
                  post_metadata_txt_pattern: Optional[str] = None,
@@ -1405,6 +1406,8 @@ class Instaloader:
                           igtv: bool = False,
                           highlights: bool = False,
                           stories: bool = False,
+                          reels: bool = False,
+                          browser: bool = False,
                           fast_update: bool = False,
                           post_filter: Optional[Callable[[Post], bool]] = None,
                           storyitem_filter: Optional[Callable[[Post], bool]] = None,
@@ -1482,6 +1485,23 @@ class Instaloader:
                     with self.context.error_catcher('Download IGTV of {}'.format(profile_name)):
                         self.download_igtv(profile, fast_update=fast_update, post_filter=post_filter,
                                            latest_stamps=latest_stamps)
+                        
+                if reels:
+                    print(browser)
+                    print('that was browser')
+                    self.context.log('....WELCOME TO THE SHOW')
+                    
+                    if os.system('gallery-dl --version') != 0:
+                        print("oh no why dont you try pip install -U gallery-dl")
+                    else:
+                        if browser:
+                            command = f'gallery-dl --dest {profile_name} --cookies-from-browser {browser} https://www.instagram.com/{profile_name}/reels/'
+                            print('#'*90)
+                            print(command)
+                            print('#'*90)
+                            os.system(command)
+                        else:
+                            os.system(f'gallery-dl --dest {profile_name} https://www.instagram.com/{profile_name}/reels/')
 
                 # Download highlights, if requested
                 if highlights:


### PR DESCRIPTION
This adds the --reels option but you must have gallery-dl installed with `pip install -U gallery-dl` and ideally use the browser cookies option

WORKING:
`instaloader --reels myprofile --load-cookies firefox`

The documentation is not updated, and it is not a proof of concept because it is working :)

You can help me implement an actual working reels downloader by explaining how I can print the response returned by IG. edge_felix_video_timeline is some metadata that generates a key error https://github.com/instaloader/instaloader/issues/2285 and I have no idea what i should be looking for.

My solution only downloads the reels itself (mp4) and it does not have statistics such as comments or amount of plays.

```bash
git clone https://github.com/jpfleischer/instaloader.git
cd instaloader
pip install -e .
instaloader --reels myprofile --load-cookies firefox
```