### PR TITLE
PEP 561 compliance enhancement for issue #2313

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -351,7 +351,7 @@ single-line-if-stmt=no
 allow-any-import-level=
 
 # Allow explicit reexports by alias from a package __init__.
-allow-reexport-from-package=no
+allow-reexport-from-package=yes
 
 # Allow wildcard imports from modules that define __all__.
 allow-wildcard-with-all=no

--- a/instaloader/__init__.py
+++ b/instaloader/__init__.py
@@ -13,11 +13,26 @@ else:
     win_unicode_console.enable()
 
 from .exceptions import *
-from .instaloader import Instaloader
-from .instaloadercontext import InstaloaderContext, RateController
-from .lateststamps import LatestStamps
-from .nodeiterator import NodeIterator, FrozenNodeIterator, resumable_iteration
-from .structures import (Hashtag, Highlight, Post, PostSidecarNode, PostComment, PostCommentAnswer, PostLocation,
-                         Profile, Story, StoryItem, TopSearchResults, TitlePic,
-                         load_structure_from_file, save_structure_to_file,
-                         load_structure, get_json_structure)
+from .instaloader import Instaloader as Instaloader
+from .instaloadercontext import (InstaloaderContext as InstaloaderContext,
+                                 RateController as RateController)
+from .lateststamps import LatestStamps as LatestStamps
+from .nodeiterator import (NodeIterator as NodeIterator,
+                           FrozenNodeIterator as FrozenNodeIterator,
+                           resumable_iteration as resumable_iteration)
+from .structures import (Hashtag as Hashtag,
+                         Highlight as Highlight,
+                         Post as Post,
+                         PostSidecarNode as PostSidecarNode,
+                         PostComment as PostComment,
+                         PostCommentAnswer as PostCommentAnswer,
+                         PostLocation as PostLocation,
+                         Profile as Profile,
+                         Story as Story,
+                         StoryItem as StoryItem,
+                         TopSearchResults as TopSearchResults,
+                         TitlePic as TitlePic,
+                         load_structure_from_file as load_structure_from_file,
+                         save_structure_to_file as save_structure_to_file,
+                         load_structure as load_structure,
+                         get_json_structure as get_json_structure)


### PR DESCRIPTION
PEP 561 compliance enhancement for issue #2313
By the PEP 484 and PEP 561 some of the modules api's aren't exported, so this pull request fixes it, at least partially.

Changed only `__init__.py` file with this pattern
`from .X import A` -> `from .X import A as A`
`from .X import (A, B)` -> `from .X import (A as A, B as B)`
Addition of redundant `as` operator by the [PEP 484](https://peps.python.org/pep-0484/#stub-files) marks elements as exported.

I don't know if these are all the changes needed. This is the only thing that was tearing my work apart.
I think it's ready to merge.