### PR TITLE
Use new doc_id based query to get posts

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -407,7 +407,7 @@ class InstaloaderContext:
         is_graphql_query = 'query_hash' in params and 'graphql/query' in path
         is_doc_id_query = 'doc_id' in params and 'graphql/query' in path
         is_iphone_query = host == 'i.instagram.com'
-        is_other_query = not is_graphql_query and host == "www.instagram.com"
+        is_other_query = not is_graphql_query and not is_doc_id_query and host == "www.instagram.com"
         sess = session if session else self._session
         try:
             self.do_sleep()

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -392,13 +392,17 @@ class InstaloaderContext:
         """JSON request to Instagram.
 
         :param path: URL, relative to the given domain which defaults to www.instagram.com/
-        :param params: GET parameters
+        :param params: request parameters
         :param host: Domain part of the URL from where to download the requested JSON; defaults to www.instagram.com
         :param session: Session to use, or None to use self.session
+        :param use_post: Use POST instead of GET to make the request
         :return: Decoded response dictionary
         :raises QueryReturnedBadRequestException: When the server responds with a 400.
         :raises QueryReturnedNotFoundException: When the server responds with a 404.
         :raises ConnectionException: When query repeatedly failed.
+
+        .. versionchanged:: 4.13
+           Added `use_post` parameter.
         """
         is_graphql_query = 'query_hash' in params and 'graphql/query' in path
         is_doc_id_query = 'doc_id' in params and 'graphql/query' in path
@@ -520,6 +524,16 @@ class InstaloaderContext:
 
     def doc_id_graphql_query(self, doc_id: str, variables: Dict[str, Any],
                              referer: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Do a doc_id-based GraphQL Query using method POST.
+
+        .. versionadded:: 4.13
+
+        :param doc_id: doc_id for the query.
+        :param variables: Variables for the Query.
+        :param referer: HTTP Referer, or None.
+        :return: The server's response dictionary.
+        """
         with copy_session(self._session, self.request_timeout) as tmpsession:
             tmpsession.headers.update(self._default_http_header(empty_session_only=True))
             del tmpsession.headers['Connection']

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -99,11 +99,11 @@ class NodeIterator(Iterator[T]):
 
     def _query(self, after: Optional[str] = None) -> Dict:
         if self._doc_id is not None:
-            return self._query_doc_id(after)
+            return self._query_doc_id(self._doc_id, after)
         else:
-            return self._query_query_hash
+            return self._query_query_hash(after)
 
-    def _query_doc_id(self, after: Optional[str] = None) -> Dict:
+    def _query_doc_id(self, doc_id: str, after: Optional[str] = None) -> Dict:
         pagination_variables: Dict[str, Any] = {'__relay_internal__pv__PolarisFeedShareMenurelayprovider': False}
         if after is not None:
             pagination_variables['after'] = after
@@ -112,7 +112,7 @@ class NodeIterator(Iterator[T]):
             pagination_variables['last'] = None
         data = self._edge_extractor(
             self._context.doc_id_graphql_query(
-                self._doc_id, {**self._query_variables, **pagination_variables}, self._query_referer
+                doc_id, {**self._query_variables, **pagination_variables}, self._query_referer
             )
         )
         self._best_before = datetime.now() + NodeIterator._shelf_life

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -105,6 +105,7 @@ class NodeIterator(Iterator[T]):
         if self._doc_id is not None:
             return self._query_doc_id(self._doc_id, after)
         else:
+            assert self._query_hash is not None
             return self._query_query_hash(self._query_hash, after)
 
     def _query_doc_id(self, doc_id: str, after: Optional[str] = None) -> Dict:

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -29,6 +29,7 @@ FrozenNodeIterator.best_before.__doc__ = """Date when parts of the stored nodes 
 FrozenNodeIterator.remaining_data.__doc__ = \
     """The already-retrieved, yet-unprocessed ``edges`` and the ``page_info`` at time of freezing."""
 FrozenNodeIterator.first_node.__doc__ = """Node data of the first item, if an item has been produced."""
+FrozenNodeIterator.doc_id.__doc__ = """The GraphQL ``doc_id`` parameter."""
 
 T = TypeVar('T')
 

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -251,8 +251,6 @@ class NodeIterator(Iterator[T]):
         self._data = frozen.remaining_data
         if frozen.first_node is not None:
             self._first_node = frozen.first_node
-        if frozen.doc_id is not None:
-            self._doc_id = frozen.doc_id
 
 
 @contextmanager

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -66,6 +66,9 @@ class NodeIterator(Iterator[T]):
     NodeIterators are matching if and only if they have the same magic.
 
     See also :func:`resumable_iteration` for a high-level context manager that handles a resumable iteration.
+
+    .. versionchanged: 4.13
+       Included support for `doc_id`-based queries (using POST method).
     """
 
     _graphql_page_length = 12

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -236,11 +236,11 @@ class Post:
         }
         with suppress(KeyError):
             fake_node["display_url"] = media['image_versions2']['candidates'][0]['url']
-        with suppress(KeyError):
+        with suppress(KeyError, TypeError):
             fake_node["video_url"] = media['video_versions'][-1]['url']
             fake_node["video_duration"] = media["video_duration"]
             fake_node["video_view_count"] = media["view_count"]
-        with suppress(KeyError):
+        with suppress(KeyError, TypeError):
             fake_node["edge_sidecar_to_children"] = {"edges": [{"node": {
                 "display_url": node['image_versions2']['candidates'][0]['url'],
                 "is_video": media_types[node["media_type"]] == "GraphVideo",
@@ -1175,13 +1175,17 @@ class Profile:
         self._obtain_metadata()
         return NodeIterator(
             self._context,
-            '003056d32c2554def87228bc3fd9668a',
-            lambda d: d['data']['user']['edge_owner_to_timeline_media'],
-            lambda n: Post(self._context, n, self),
-            {'id': self.userid},
+            '',
+            lambda d: d['data']['xdt_api__v1__feed__user_timeline_graphql_connection'],
+            lambda n: Post.from_iphone_struct(self._context, n),
+            {'data': {
+                'count': 12, 'include_relationship_info': True,
+                'latest_besties_reel_media': True, 'latest_reel_media': True},
+             'username': self.username},
             'https://www.instagram.com/{0}/'.format(self.username),
-            self._metadata('edge_owner_to_timeline_media'),
-            Profile._make_is_newest_checker()
+            None,
+            Profile._make_is_newest_checker(),
+            '7898261790222653'
         )
 
     def get_saved_posts(self) -> NodeIterator[Post]:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -232,6 +232,8 @@ class Post:
             "title": media.get("title"),
             "viewer_has_liked": media["has_liked"],
             "edge_media_preview_like": {"count": media["like_count"]},
+            "accessibility_caption": media.get("accessibility_caption"),
+            "comments": media.get("comment_count"),
             "iphone_struct": media,
         }
         with suppress(KeyError):

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1185,18 +1185,17 @@ class Profile:
         :rtype: NodeIterator[Post]"""
         self._obtain_metadata()
         return NodeIterator(
-            self._context,
-            '',
-            lambda d: d['data']['xdt_api__v1__feed__user_timeline_graphql_connection'],
-            lambda n: Post.from_iphone_struct(self._context, n),
-            {'data': {
+            context = self._context,
+            edge_extractor = lambda d: d['data']['xdt_api__v1__feed__user_timeline_graphql_connection'],
+            node_wrapper = lambda n: Post.from_iphone_struct(self._context, n),
+            query_variables = {'data': {
                 'count': 12, 'include_relationship_info': True,
                 'latest_besties_reel_media': True, 'latest_reel_media': True},
              'username': self.username},
-            'https://www.instagram.com/{0}/'.format(self.username),
-            None,
-            Profile._make_is_newest_checker(),
-            '7898261790222653'
+            query_referer = 'https://www.instagram.com/{0}/'.format(self.username),
+            is_first = Profile._make_is_newest_checker(),
+            doc_id = '7898261790222653',
+            query_hash = None,
         )
 
     def get_saved_posts(self) -> NodeIterator[Post]:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -241,11 +241,20 @@ class Post:
             fake_node["video_duration"] = media["video_duration"]
             fake_node["video_view_count"] = media["view_count"]
         with suppress(KeyError, TypeError):
-            fake_node["edge_sidecar_to_children"] = {"edges": [{"node": {
-                "display_url": node['image_versions2']['candidates'][0]['url'],
-                "is_video": media_types[node["media_type"]] == "GraphVideo",
-            }} for node in media["carousel_media"]]}
+            fake_node["edge_sidecar_to_children"] = {"edges": [{"node":
+                Post._convert_iphone_carousel(node, media_types)}
+                for node in media["carousel_media"]]}
         return cls(context, fake_node, Profile.from_iphone_struct(context, media["user"]) if "user" in media else None)
+
+    @staticmethod
+    def _convert_iphone_carousel(iphone_node: Dict[str, Any], media_types: Dict[int, str]) -> Dict[str, Any]:
+        fake_node = {
+            "display_url": iphone_node["image_versions2"]["candidates"][0]["url"],
+            "is_video": media_types[iphone_node["media_type"]] == "GraphVideo",
+        }
+        if "video_versions" in iphone_node and iphone_node["video_versions"] is not None:
+            fake_node["video_url"] = iphone_node["video_versions"][0]["url"]
+        return fake_node
 
     @staticmethod
     def shortcode_to_mediaid(code: str) -> int:


### PR DESCRIPTION
Fixes #2319.

This uses the new query to retrieve user posts as discussed in the bug comments.

The returned object is (almost) equal to what was returned by the "iphone queries". (But it `video_versions` is null for images (and maybe sidecars), and `carousel_media` is null for non-sidecars, so I suppressed the `TypeError` that happens when trying to index a `None`.

  - **Is it just a proof of concept?** No, should be complete.
  - **Is the documentation updated (if appropriate)?** Yes. Nothing changed for the user, only the module documentation was updated.
  - **Do you consider it ready to be merged or is it a draft?** Should be now ready.
  - **Can we help you at some point?** Suggestions are welcome.