### PR TITLE
minor doc update in basic-usage.rst

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -231,7 +231,7 @@ The filter string must be a
 where the attributes from :class:`Post` or
 :class:`StoryItem` respectively are defined.
 
-Id est, the following attributes can be used with both
+The following attributes can be used with both
 :option:`--post-filter` and :option:`--storyitem-filter`:
 
 - :attr:`~Post.owner_username` (str), :attr:`~Post.owner_id` (int)


### PR DESCRIPTION
(almost) nobody says "Id est". Even I, being a native English speaker, had to search for it. It should've been "i.e." in the first place. But, even that is not needed. Let's keep it simple.
