### PR TITLE
Clarify that post short codes should be preceded by a hyphen

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -122,7 +122,8 @@ Instaloader supports the following targets:
 
 - ``-post``
    Replace **post** with the post's shortcode to download single post. Must be preceded by ``--`` in
-   the argument list to not be mistaken as an option flag::
+   the argument list to not be mistaken as an option flag.  For example, to download the post
+   https://www.instagram.com/p/**B_K4CykAOtf**, run the command::
 
     instaloader -- -B_K4CykAOtf
 


### PR DESCRIPTION
I found the documentation for downloading single posts confusing (and I’m not the only one, e.g. #471).

When I read the example command, I thought that the leading hyphen in `-B_K4CykAOtf` was part of the shortcode – I was trying to download an Instagram post with a hyphen in the shortcode, and [some posts](https://www.instagram.com/p/-9WYAqqvSV/) have a shortcode that starts with a hyphen!

Having the URL there for a point of comparison should make this clearer.

<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
