### PR TITLE
pass max_count var to func download_profiles to fix PR #2276

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -300,7 +300,8 @@ def _main(instaloader: Instaloader, targetlist: List[str],
         instaloader.download_profiles(profiles,
                                       download_profile_pic, download_posts, download_tagged, download_igtv,
                                       download_highlights, download_stories,
-                                      fast_update, post_filter, storyitem_filter, latest_stamps=latest_stamps)
+                                      fast_update, post_filter, storyitem_filter, latest_stamps=latest_stamps,
+                                      max_count=max_count)
         if anonymous_retry_profiles:
             instaloader.context.log("Downloading anonymously: {}"
                                     .format(' '.join([p.username for p in anonymous_retry_profiles])))


### PR DESCRIPTION
Fixes #2339

PR #2276 added max_count var to the ``download_profiles`` function but the ``max_count`` var was not being passed from the function in ``__main__.py`` that calls download_profiles.

This PR corrects that.
<!--
Thanks for your willingness to contribute to Instaloader! Please briefly
describe

- A motivation for this change, e.g.
  - Fixes # .
  - More general: What problem does the pull request solve?

- The changes proposed in this pull request

- The completeness of this change
  - Is it just a proof of concept?
  - Is the documentation updated (if appropriate)?
  - Do you consider it ready to be merged or is it a draft?
  - Can we help you at some point?
-->
