### PR TITLE
Introductory fix to issue #2384

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -721,7 +721,7 @@ class Instaloader:
 
         # Download the image(s) / video thumbnail and videos within sidecars if desired
         downloaded = True
-        if post.typename == 'GraphSidecar':
+        if post.typename == 'XDTGraphSidecar':
             if (self.download_pictures or self.download_videos) and post.mediacount > 0:
                 if not _all_already_downloaded(
                         filename_template, enumerate(
@@ -753,12 +753,12 @@ class Instaloader:
                                                             mtime=post.date_local, filename_suffix=suffix)
                 else:
                     downloaded = False
-        elif post.typename == 'GraphImage':
+        elif post.typename == 'XDTGraphImage':
             # Download picture
             if self.download_pictures:
                 downloaded = (not _already_downloaded(filename + ".jpg") and
                               self.download_pic(filename=filename, url=post.url, mtime=post.date_local))
-        elif post.typename == 'GraphVideo':
+        elif post.typename == 'XDTGraphVideo':
             # Download video thumbnail (--no-pictures implies --no-video-thumbnails)
             if self.download_pictures and self.download_video_thumbnails:
                 with self.context.error_catcher("Video thumbnail of {}".format(post)):

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -496,6 +496,7 @@ class InstaloaderContext:
         .. versionchanged:: 4.13.1
            Removed the `rhx_gis` parameter.
         """
+
         with copy_session(self._session, self.request_timeout) as tmpsession:
             tmpsession.headers.update(self._default_http_header(empty_session_only=True))
             del tmpsession.headers['Connection']
@@ -508,12 +509,21 @@ class InstaloaderContext:
 
             variables_json = json.dumps(variables, separators=(',', ':'))
 
-            resp_json = self.get_json('graphql/query',
-                                      params={'query_hash': query_hash,
-                                              'variables': variables_json},
-                                      session=tmpsession)
+            # XXX Dirty fix here
+            if query_hash == "2b0673e0dc4580674a88d426fe00ea90":
+                resp_json = self.get_json('graphql/query',
+                                          params={'doc_id': '8845758582119845',
+                                                  'variables': variables_json},
+                                          session=tmpsession)
+
+            else:
+                resp_json = self.get_json('graphql/query',
+                                          params={'query_hash': query_hash,
+                                                  'variables': variables_json},
+                                          session=tmpsession)
         if 'status' not in resp_json:
             self.error("GraphQL response did not contain a \"status\" field.")
+
         return resp_json
 
     def doc_id_graphql_query(self, doc_id: str, variables: Dict[str, Any],


### PR DESCRIPTION
This is a draft intended to bootstrap the resolution of issue #2384

Fix to reflect changes of the Instagram API (hinted here https://github.com/yt-dlp/yt-dlp/commit/cf85cba5d9496bd2689e1070005b4d1b4cd3dc6d)

I know neither python nor the codebase so I didn't take the time to refactor anything (graphql_query now takes a wrongly named parameter query_hash) and just surrounded the API call with an if/else.

In the current state I only tested it to work with shortcodes (ex. `instaloader -- -DAOdehwP6fC` now works as expected) and nothing else.