### PR TITLE
Bump pipenv, remove Python 3.8, add Python 3.13

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
           cache: 'pipenv'
       - name: "Install Dependencies"
         run: |
-          python -m pip install pipenv==2024.0.1
+          python -m pip install pipenv==2024.2.0
           pipenv --python `python --version | grep -Eo '3\.[0-9]+'` sync --dev
       - name: "Build Documentation"
         run: pipenv --python `python --version | grep -Eo '3\.[0-9]+'` run make -C docs html SPHINXOPTS="-W -n"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout Instaloader Repository
         uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
           cache: 'pipenv'
       - name: Install Dependencies
         run: |
-          python -m pip install pipenv==2024.0.1
+          python -m pip install pipenv==2024.2.0
           pipenv --python `python --version | grep -Eo '3\.[0-9]+'` sync --dev
       - name: PyLint
         run: pipenv --python `python --version | grep -Eo '3\.[0-9]+'` run pylint instaloader

--- a/deploy/windows/create_exe.py
+++ b/deploy/windows/create_exe.py
@@ -44,7 +44,7 @@ with open('__main__.py', 'w+') as f:
     f.writelines(lines)
 
 # install dependencies and invoke PyInstaller
-commands = ["pip install pipenv==2024.0.1",
+commands = ["pip install pipenv==2024.2.0",
             f"pipenv --python {sys.version_info.major}.{sys.version_info.minor} sync --dev",
             "pipenv run pyinstaller --log-level=DEBUG instaloader.spec"]
 

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ def get_version():
     raise SystemExit("Could not find version string.")
 
 
-if sys.version_info < (3, 8):
-    sys.exit('Instaloader requires Python >= 3.8.')
+if sys.version_info < (3, 9):
+    sys.exit('Instaloader requires Python >= 3.9.')
 
-requirements = ['requests>=2.4']
+requirements = ['requests>=2.32']
 optional_requirements = {
     'browser_cookie3': ['browser_cookie3>=0.19.1'],
 }
@@ -46,7 +46,7 @@ setup(
                 'from Instagram.',
     long_description=open(os.path.join(SRC, 'README.rst')).read(),
     install_requires=requirements,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     extras_require=optional_requirements,
     entry_points={'console_scripts': ['instaloader=instaloader.__main__:main']},
     zip_safe=False,
@@ -58,11 +58,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet',
         'Topic :: Multimedia :: Graphics'

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_version():
 if sys.version_info < (3, 9):
     sys.exit('Instaloader requires Python >= 3.9.')
 
-requirements = ['requests>=2.32']
+requirements = ['requests>=2.25']
 optional_requirements = {
     'browser_cookie3': ['browser_cookie3>=0.19.1'],
 }


### PR DESCRIPTION
Python 3.8 is EOL. This PR removes it from lint.yml and add in 3.13.

Bumping pipenv to the latest version to support 3.13.