### PR TITLE
Fix anonymous fetch of users and posts

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -32,15 +32,15 @@ def copy_session(session: requests.Session, request_timeout: Optional[float] = N
 
 def default_user_agent() -> str:
     return ('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
-            '(KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36')
+            '(KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36')
 
 
 def default_iphone_headers() -> Dict[str, Any]:
-    return {'User-Agent': 'Instagram 273.0.0.16.70 (iPad13,8; iOS 16_3; en_US; en-US; ' \
-                          'scale=2.00; 2048x2732; 452417278) AppleWebKit/420+',
+    return {'User-Agent': 'Instagram 361.0.0.35.82 (iPad13,8; iOS 18_0; en_US; en-US; ' \
+                          'scale=2.00; 2048x2732; 674117118) AppleWebKit/420+',
             'x-ads-opt-out': '1',
             'x-bloks-is-panorama-enabled': 'true',
-            'x-bloks-version-id': '01507c21540f73e2216b6f62a11a5b5e51aa85491b72475c080da35b1228ddd6',
+            'x-bloks-version-id': '16b7bd25c6c06886d57c4d455265669345a2d96625385b8ee30026ac2dc5ed97',
             'x-fb-client-ip': 'True',
             'x-fb-connection-type': 'wifi',
             'x-fb-http-engine': 'Liger',


### PR DESCRIPTION
Hello! This PR aims to fix the problem that caused many and many users to be unable to download anything, either profiles and posts. 

This problem affected a lot of us, but in the end, there was simply some backend change made by Instagram, so it was needed to change some parameters and adapt to the new responses, and now some things like `_convert_iphone_carousel` are not even needed anymore.

Actually there are way more incompatible changes (i.e. logged in user doesn't work, neither the fetching of users by their id) so someone should take care also to that.

  - Is it just a proof of concept? **No**
  - Is the documentation updated (if appropriate)? **No**
  - Do you consider it ready to be merged or is it a draft? **Ready**
  - Can we help you at some point? **No**
  
I think I made all the changes correctly, but a deeper look from a more experienced "instaloader developer" would be appreciated, thanks!

Fixes #2532, #2528, #2307, #2517, #2501, #2511, #2508
