### PR TITLE
Check up to 6 pinned posts

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1542,7 +1542,7 @@ class Instaloader:
                     posts_to_download = profile.get_posts()
                     self.posts_download_loop(posts_to_download, profile_name, fast_update, post_filter,
                                              total_count=profile.mediacount, owner_profile=profile,
-                                             takewhile=posts_takewhile, possibly_pinned=3, max_count=max_count)
+                                             takewhile=posts_takewhile, possibly_pinned=6, max_count=max_count)
                     if latest_stamps is not None and posts_to_download.first_item is not None:
                         latest_stamps.set_last_post_timestamp(profile_name,
                                                               posts_to_download.first_item.date_local)


### PR DESCRIPTION
As mentioned in #2536, it is now possible to pin up to 6 posts, so this change increases the number of posts that are checked for being possibly pinned when using --latest-stamps.

  - Is it just a proof of concept? No
  - Is the documentation updated (if appropriate)? Not necessary
  - Do you consider it ready to be merged or is it a draft? Ready
  - Can we help you at some point? Not necessary.
