### PR TITLE
Add `possibly_pinned` to download reels loop

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1296,14 +1296,8 @@ class Instaloader:
             last_scraped = latest_stamps.get_last_reels_timestamp(profile.username)
             posts_takewhile = lambda p: p.date_local > last_scraped
         reels = profile.get_reels()
-        self.posts_download_loop(
-            reels,
-            profile.username,
-            fast_update,
-            post_filter,
-            owner_profile=profile,
-            takewhile=posts_takewhile,
-        )
+        self.posts_download_loop(reels, profile.username, fast_update, post_filter,
+                                 owner_profile=profile, takewhile=posts_takewhile, possibly_pinned=3)
         if latest_stamps is not None and reels.first_item is not None:
             latest_stamps.set_last_reels_timestamp(profile.username, reels.first_item.date_local)
 

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1296,8 +1296,15 @@ class Instaloader:
             last_scraped = latest_stamps.get_last_reels_timestamp(profile.username)
             posts_takewhile = lambda p: p.date_local > last_scraped
         reels = profile.get_reels()
-        self.posts_download_loop(reels, profile.username, fast_update, post_filter,
-                                 owner_profile=profile, takewhile=posts_takewhile, possibly_pinned=3)
+        self.posts_download_loop(
+            reels,
+            profile.username,
+            fast_update,
+            post_filter,
+            owner_profile=profile,
+            takewhile=posts_takewhile,
+            possibly_pinned=3,
+        )
         if latest_stamps is not None and reels.first_item is not None:
             latest_stamps.set_last_reels_timestamp(profile.username, reels.first_item.date_local)
 


### PR DESCRIPTION
  - Fixes #2536 
  - Fixes #2441
  
  - _More general:_ Reels have a separate tab on user's profile, and can have independently pinned videos (up to 3). Instaloader did not account for that

- _The changes proposed in this pull request:_ Add `possibly_pinned` to download reels loop

- The completeness of this change
  - _Is it just a proof of concept?_ - No
  - _Is the documentation updated (if appropriate)?_ - N/A
  - _Do you consider it ready to be merged or is it a draft?_ - Ready to be merged
  - _Can we help you at some point?_ - Thanks to @ekalin for the tip: https://github.com/instaloader/instaloader/issues/2536#issuecomment-2755529852
