### PR TITLE
Update session import

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -82,24 +82,16 @@ def filterstr_to_filterfunc(filter_str: str, item_type: type):
     return filterfunc
 
 
-def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
+def get_cookies_from_instagram(domain, browser, cookie_file=None, cookie_name=''):
     supported_browsers = {
-        "brave": browser_cookie3.brave,
-        "chrome": browser_cookie3.chrome,
-        "chromium": browser_cookie3.chromium,
-        "edge": browser_cookie3.edge,
         "firefox": browser_cookie3.firefox,
         "librewolf": browser_cookie3.librewolf,
-        "opera": browser_cookie3.opera,
-        "opera_gx": browser_cookie3.opera_gx,
-        "safari": browser_cookie3.safari,
-        "vivaldi": browser_cookie3.vivaldi,
+        "safari": browser_cookie3.safari
     }
 
     if browser not in supported_browsers:
         raise InvalidArgumentException("Loading cookies from the specified browser failed\n"
-                                       "Supported browsers are Brave, Chrome, Chromium, Edge, Firefox, LibreWolf, "
-                                       "Opera, Opera_GX, Safari and Vivaldi")
+                                       "Supported browsers are Firefox, LibreWolf and Safari")
 
     cookies = {}
     browser_cookies = list(supported_browsers[browser](cookie_file=cookie_file))
@@ -120,7 +112,7 @@ def get_cookies_from_instagram(domain, browser, cookie_file='', cookie_name=''):
         return cookies
 
 
-def import_session(browser, instaloader, cookiefile):
+def import_session(browser, instaloader, cookiefile=None):
     cookie = get_cookies_from_instagram('instagram', browser, cookiefile)
     if cookie is not None:
         instaloader.context.update_cookies(cookie)


### PR DESCRIPTION
Fixes:
- #2510 
- #2550
- #2552
- #2576

Removes Chromium-based browsers from get_cookies_from_instagram (and correspondingly updates the docs).
_Reason: browser_cookie3 has not been updated after Chromium improved cookie encryption._

Adds a default value (None) for cookiefile in import_session (_as expected by browser_cookie3_).
Changes cookie_file default value to None in get_cookies_from_instagram (_as expected by browser_cookie3_).

**Ready to be merged**
