### PR TITLE
Add SYSTEMEXITs to get_json for substantial Instagram requirements

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -395,7 +395,8 @@ class InstaloaderContext:
         :param session: Session to use, or None to use self.session
         :param use_post: Use POST instead of GET to make the request
         :return: Decoded response dictionary
-        :raises QueryReturnedBadRequestException: When the server responds with a 400.
+        :raises AbortDownloadException: When the server responds with "feedback_required"/"challenge_required"
+        :raises QueryReturnedBadRequestException: When the server responds with a 400 (and not "feedback_required"/"challenge_required").
         :raises QueryReturnedNotFoundException: When the server responds with a 404.
         :raises ConnectionException: When query repeatedly failed.
 
@@ -447,12 +448,14 @@ class InstaloaderContext:
                 response_headers.clear()
                 response_headers.update(resp.headers)
             if resp.status_code == 400:
-                #SYSTEMEXIT in case of substantial Instagram requirements (to stop producing requests)
+                # Raise AbortDownloadException in case of substantial Instagram requirements to stop producing more requests
                 if "message" in resp_json:
                     if "feedback_required" in resp_json['message']:
-                        raise SystemExit("The module execution stopped as Instagram’s anti-bot safety system has been set off. Please try again in several (up to 24) hours.")
+                        raise AbortDownloadException("The module execution stopped as Instagram’s anti-bot safety system has been set off. " +
+                                                     "Please try again in several (up to 24) hours.")
                     elif "challenge_required" in resp_json['message']:
-                        raise SystemExit("The module execution stopped as your Instagram account is either suspended or disabled. Please check your email for further steps (you may be required to go through a verification process).")
+                        raise AbortDownloadException("The module execution stopped as your Instagram account is either suspended or disabled. " +
+                                                     "Please check your email for further steps (you may be required to go through a verification process).")
                 raise QueryReturnedBadRequestException(self._response_error(resp))
             if resp.status_code == 404:
                 raise QueryReturnedNotFoundException(self._response_error(resp))


### PR DESCRIPTION
When Instagram returns "_feedback_required_" or "_challenge_required_", any further requests will be declined until the required action is performed manually. Those messages mean Instagram suspects us of being a bot, so we must stop producing more requests immediately in order not to increase the suspicions.

The PR adds SYSTEMEXITs to get_json (status_code 400 block) for substantial Instagram requirements (feedback_required | challenge_required), providing detailed explanations to the console.

The documentation does not seem to need to be updated.

**Ready to be merged**
