### PR TITLE
feat: Improved CLI interface

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -2,26 +2,32 @@
 
 import ast
 import datetime
+import logging
 import os
 import re
 import sys
-from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
+from argparse import ArgumentTypeError
 from enum import IntEnum
+from pathlib import Path
 from typing import List, Optional
 
-from . import (AbortDownloadException, BadCredentialsException, Instaloader, InstaloaderException,
-               InvalidArgumentException, LoginException, Post, Profile, ProfileNotExistsException, StoryItem,
-               TwoFactorAuthRequiredException, __version__, load_structure_from_file)
-from .instaloader import (get_default_session_filename, get_default_stamps_filename)
-from .instaloadercontext import default_user_agent
+from mininterface import run
+
+from . import (AbortDownloadException, BadCredentialsException, Instaloader,
+               InstaloaderException, InvalidArgumentException, LoginException,
+               Post, Profile, ProfileNotExistsException, StoryItem,
+               TwoFactorAuthRequiredException, __version__,
+               load_structure_from_file)
+from .cli import Env
 from .lateststamps import LatestStamps
+
 try:
     import browser_cookie3
     bc3_library = True
 except ImportError:
     bc3_library = False
 
-
+logger = logging.getLogger(__name__)
 class ExitCode(IntEnum):
     SUCCESS = 0
     NON_FATAL_ERROR = 1
@@ -42,7 +48,7 @@ def usage_string():
 {2:{1}} profile | "#hashtag" | %%location_id | :stories | :feed | :saved
 {0} --help""".format(argv0, len(argv0), '')
 
-
+# TODO remove
 def http_status_code_list(code_list_str: str) -> List[int]:
     codes = [int(s) for s in code_list_str.split(',')]
     for code in codes:
@@ -350,197 +356,30 @@ def _main(instaloader: Instaloader, targetlist: List[str],
 
 
 def main():
-    parser = ArgumentParser(description=__doc__, add_help=False, usage=usage_string(),
-                            epilog="The complete documentation can be found at "
-                                   "https://instaloader.github.io/.",
-                            fromfile_prefix_chars='+')
+    m = run(Env, description=__doc__,  usage=usage_string(),
+                        epilog="The complete documentation can be found at "
+                                "https://instaloader.github.io/.",
+                        fromfile_prefix_chars='+', ask_on_empty_cli=True, add_version=__version__, add_quiet=True, allow_abbrev=True)
+    args = m.env
 
-    g_targets = parser.add_argument_group("What to Download",
-                                          "Specify a list of targets. For each of these, Instaloader creates a folder "
-                                          "and downloads all posts. The following targets are supported:")
-    g_targets.add_argument('profile', nargs='*',
-                           help="Download profile. If an already-downloaded profile has been renamed, Instaloader "
-                                "automatically finds it by its unique ID and renames the folder likewise.")
-    g_targets.add_argument('_at_profile', nargs='*', metavar="@profile",
-                           help="Download all followees of profile. Requires login. "
-                                "Consider using :feed rather than @yourself.")
-    g_targets.add_argument('_hashtag', nargs='*', metavar='"#hashtag"', help="Download #hashtag.")
-    g_targets.add_argument('_location', nargs='*', metavar='%location_id',
-                           help="Download %%location_id. Requires login.")
-    g_targets.add_argument('_feed', nargs='*', metavar=":feed",
-                           help="Download pictures from your feed. Requires login.")
-    g_targets.add_argument('_stories', nargs='*', metavar=":stories",
-                           help="Download the stories of your followees. Requires login.")
-    g_targets.add_argument('_saved', nargs='*', metavar=":saved",
-                           help="Download the posts that you marked as saved. Requires login.")
-    g_targets.add_argument('_singlepost', nargs='*', metavar="-- -shortcode",
-                           help="Download the post with the given shortcode")
-    g_targets.add_argument('_json', nargs='*', metavar="filename.json[.xz]",
-                           help="Re-Download the given object.")
-    g_targets.add_argument('_fromfile', nargs='*', metavar="+args.txt",
-                           help="Read targets (and options) from given textfile.")
+    # miniterface takes care of the commen flags like --quiet, hence we determine the quietness from the system logger
+    quiet = logger.getEffectiveLevel() == logging.ERROR
 
-    g_post = parser.add_argument_group("What to Download of each Post")
-
-    g_prof = parser.add_argument_group("What to Download of each Profile")
-
-    g_prof.add_argument('-P', '--profile-pic-only', action='store_true',
-                        help=SUPPRESS)
-    g_prof.add_argument('--no-posts', action='store_true',
-                        help="Do not download regular posts.")
-    g_prof.add_argument('--no-profile-pic', action='store_true',
-                        help='Do not download profile picture.')
-    g_post.add_argument('--slide', action='store',
-                        help='Set what image/interval of a sidecar you want to download.')
-    g_post.add_argument('--no-pictures', action='store_true',
-                        help='Do not download post pictures. Cannot be used together with --fast-update. '
-                             'Implies --no-video-thumbnails, does not imply --no-videos.')
-    g_post.add_argument('-V', '--no-videos', action='store_true',
-                        help='Do not download videos.')
-    g_post.add_argument('--no-video-thumbnails', action='store_true',
-                        help='Do not download thumbnails of videos.')
-    g_post.add_argument('-G', '--geotags', action='store_true',
-                        help='Download geotags when available. Geotags are stored as a '
-                             'text file with the location\'s name and a Google Maps link. '
-                             'This requires an additional request to the Instagram '
-                             'server for each picture. Requires login.')
-    g_post.add_argument('-C', '--comments', action='store_true',
-                        help='Download and update comments for each post. '
-                             'This requires an additional request to the Instagram '
-                             'server for each post, which is why it is disabled by default. Requires login.')
-    g_post.add_argument('--no-captions', action='store_true',
-                        help='Do not create txt files.')
-    g_post.add_argument('--post-metadata-txt', action='append',
-                        help='Template to write in txt file for each Post.')
-    g_post.add_argument('--storyitem-metadata-txt', action='append',
-                        help='Template to write in txt file for each StoryItem.')
-    g_post.add_argument('--no-metadata-json', action='store_true',
-                        help='Do not create a JSON file containing the metadata of each post.')
-    g_post.add_argument('--metadata-json', action='store_true',
-                        help=SUPPRESS)
-    g_post.add_argument('--no-compress-json', action='store_true',
-                        help='Do not xz compress JSON files, rather create pretty formatted JSONs.')
-    g_prof.add_argument('-s', '--stories', action='store_true',
-                        help='Also download stories of each profile that is downloaded. Requires login.')
-    g_prof.add_argument('--stories-only', action='store_true',
-                        help=SUPPRESS)
-    g_prof.add_argument('--highlights', action='store_true',
-                        help='Also download highlights of each profile that is downloaded. Requires login.')
-    g_prof.add_argument('--tagged', action='store_true',
-                        help='Also download posts where each profile is tagged.')
-    g_prof.add_argument('--reels', action='store_true',
-                        help='Also download Reels videos.')
-    g_prof.add_argument('--igtv', action='store_true',
-                        help='Also download IGTV videos.')
-
-    g_cond = parser.add_argument_group("Which Posts to Download")
-
-    g_cond.add_argument('-F', '--fast-update', action='store_true',
-                        help='For each target, stop when encountering the first already-downloaded picture. This '
-                             'flag is recommended when you use Instaloader to update your personal Instagram archive.')
-    g_cond.add_argument('--latest-stamps', nargs='?', metavar='STAMPSFILE', const=get_default_stamps_filename(),
-                        help='Store the timestamps of latest media scraped for each profile. This allows updating '
-                             'your personal Instagram archive even if you delete the destination directories. '
-                             'If STAMPSFILE is not provided, defaults to ' + get_default_stamps_filename())
-    g_cond.add_argument('--post-filter', '--only-if', metavar='filter',
-                        help='Expression that, if given, must evaluate to True for each post to be downloaded. Must be '
-                             'a syntactically valid python expression. Variables are evaluated to '
-                             'instaloader.Post attributes. Example: --post-filter=viewer_has_liked.')
-    g_cond.add_argument('--storyitem-filter', metavar='filter',
-                        help='Expression that, if given, must evaluate to True for each storyitem to be downloaded. '
-                             'Must be a syntactically valid python expression. Variables are evaluated to '
-                             'instaloader.StoryItem attributes.')
-
-    g_cond.add_argument('-c', '--count',
-                        help='Do not attempt to download more than COUNT posts. '
-                             'Applies to #hashtag, %%location_id, :feed, and :saved.')
-
-    g_login = parser.add_argument_group('Login (Download Private Profiles)',
-                                        'Instaloader can login to Instagram. This allows downloading private profiles. '
-                                        'To login, pass the --login option. Your session cookie (not your password!) '
-                                        'will be saved to a local file to be reused next time you want Instaloader '
-                                        'to login. Instead of --login, the --load-cookies option can be used to '
-                                        'import a session from a browser.')
-    g_login.add_argument('-l', '--login', metavar='YOUR-USERNAME',
-                         help='Login name (profile name) for your Instagram account.')
-    g_login.add_argument('-b', '--load-cookies', metavar='BROWSER-NAME',
-                         help='Browser name to load cookies from Instagram')
-    g_login.add_argument('-B', '--cookiefile', metavar='COOKIE-FILE',
-                         help='Cookie file of a profile to load cookies')
-    g_login.add_argument('-f', '--sessionfile',
-                         help='Path for loading and storing session key file. '
-                              'Defaults to ' + get_default_session_filename("<login_name>"))
-    g_login.add_argument('-p', '--password', metavar='YOUR-PASSWORD',
-                         help='Password for your Instagram account. Without this option, '
-                              'you\'ll be prompted for your password interactively if '
-                              'there is not yet a valid session file.')
-
-    g_how = parser.add_argument_group('How to Download')
-    g_how.add_argument('--dirname-pattern',
-                       help='Name of directory where to store posts. {profile} is replaced by the profile name, '
-                            '{target} is replaced by the target you specified, i.e. either :feed, #hashtag or the '
-                            'profile name. Defaults to \'{target}\'.')
-    g_how.add_argument('--filename-pattern',
-                       help='Prefix of filenames for posts and stories, relative to the directory given with '
-                            '--dirname-pattern. {profile} is replaced by the profile name,'
-                            '{target} is replaced by the target you specified, i.e. either :feed'
-                            '#hashtag or the profile name. Defaults to \'{date_utc}_UTC\'')
-    g_how.add_argument('--title-pattern',
-                       help='Prefix of filenames for profile pics, hashtag profile pics, and highlight covers. '
-                            'Defaults to \'{date_utc}_UTC_{typename}\' if --dirname-pattern contains \'{target}\' '
-                            'or \'{dirname}\', or if --dirname-pattern is not specified. Otherwise defaults to '
-                            '\'{target}_{date_utc}_UTC_{typename}\'.')
-    g_how.add_argument('--resume-prefix', metavar='PREFIX',
-                       help='Prefix for filenames that are used to save the information to resume an interrupted '
-                            'download.')
-    g_how.add_argument('--sanitize-paths', action='store_true',
-                       help='Sanitize paths so that the resulting file and directory names are valid on both '
-                            'Windows and Unix.')
-    g_how.add_argument('--no-resume', action='store_true',
-                       help='Do not resume a previously-aborted download iteration, and do not save such information '
-                            'when interrupted.')
-    g_how.add_argument('--use-aged-resume-files', action='store_true', help=SUPPRESS)
-    g_how.add_argument('--user-agent',
-                       help='User Agent to use for HTTP requests. Defaults to \'{}\'.'.format(default_user_agent()))
-    g_how.add_argument('-S', '--no-sleep', action='store_true', help=SUPPRESS)
-    g_how.add_argument('--max-connection-attempts', metavar='N', type=int, default=3,
-                       help='Maximum number of connection attempts until a request is aborted. Defaults to 3. If a '
-                            'connection fails, it can be manually skipped by hitting CTRL+C. Set this to 0 to retry '
-                            'infinitely.')
-    g_how.add_argument('--commit-mode', action='store_true', help=SUPPRESS)
-    g_how.add_argument('--request-timeout', metavar='N', type=float, default=300.0,
-                       help='Seconds to wait before timing out a connection request. Defaults to 300.')
-    g_how.add_argument('--abort-on', type=http_status_code_list, metavar="STATUS_CODES",
-                       help='Comma-separated list of HTTP status codes that cause Instaloader to abort, bypassing all '
-                            'retry logic.')
-    g_how.add_argument('--no-iphone', action='store_true',
-                        help='Do not attempt to download iPhone version of images and videos.')
-
-    g_misc = parser.add_argument_group('Miscellaneous Options')
-    g_misc.add_argument('-q', '--quiet', action='store_true',
-                        help='Disable user interaction, i.e. do not print messages (except errors) and fail '
-                             'if login credentials are needed but not given. This makes Instaloader suitable as a '
-                             'cron job.')
-    g_misc.add_argument('-h', '--help', action='help', help='Show this help message and exit.')
-    g_misc.add_argument('--version', action='version', help='Show version number and exit.',
-                        version=__version__)
-
-    args = parser.parse_args()
     try:
-        if (args.login is None and args.load_cookies is None) and (args.stories or args.stories_only):
+        if (args.login.login is None and args.login.load_cookies is None) and (args.profile.stories or args.profile.stories_only):
             print("Login is required to download stories.", file=sys.stderr)
-            args.stories = False
-            if args.stories_only:
+            args.profile.stories = False
+            if args.profile.stories_only:
                 raise InvalidArgumentException()
 
-        if ':feed-all' in args.profile or ':feed-liked' in args.profile:
+        if ':feed-all' in args.targets or ':feed-liked' in args.targets:
             raise InvalidArgumentException(":feed-all and :feed-liked were removed. Use :feed as target and "
                                            "eventually --post-filter=viewer_has_liked.")
 
-        post_metadata_txt_pattern = '\n'.join(args.post_metadata_txt) if args.post_metadata_txt else None
-        storyitem_metadata_txt_pattern = '\n'.join(args.storyitem_metadata_txt) if args.storyitem_metadata_txt else None
+        post_metadata_txt_pattern = '\n'.join(args.post.post_metadata_txt) if args.post.post_metadata_txt else None
+        storyitem_metadata_txt_pattern = '\n'.join(args.post.storyitem_metadata_txt) if args.post.storyitem_metadata_txt else None
 
-        if args.no_captions:
+        if args.post.no_captions:
             if not (post_metadata_txt_pattern or storyitem_metadata_txt_pattern):
                 post_metadata_txt_pattern = ''
                 storyitem_metadata_txt_pattern = ''
@@ -548,58 +387,64 @@ def main():
                 raise InvalidArgumentException("--no-captions and --post-metadata-txt or --storyitem-metadata-txt "
                                                "given; That contradicts.")
 
-        if args.no_resume and args.resume_prefix:
+        if args.download.no_resume and args.download.resume_prefix:
             raise InvalidArgumentException("--no-resume and --resume-prefix given; That contradicts.")
-        resume_prefix = (args.resume_prefix if args.resume_prefix else 'iterator') if not args.no_resume else None
+        resume_prefix = (args.download.resume_prefix if args.download.resume_prefix else 'iterator') if not args.download.no_resume else None
 
-        if args.no_pictures and args.fast_update:
+        if args.post.no_pictures and args.conditions.fast_update:
             raise InvalidArgumentException('--no-pictures and --fast-update cannot be used together.')
 
-        if args.login and args.load_cookies:
+        if args.login.login and args.login.load_cookies:
             raise InvalidArgumentException('--load-cookies and --login cannot be used together.')
 
         # Determine what to download
-        download_profile_pic = not args.no_profile_pic or args.profile_pic_only
-        download_posts = not (args.no_posts or args.stories_only or args.profile_pic_only)
-        download_stories = args.stories or args.stories_only
+        download_profile_pic = not args.profile.no_profile_pic or args.profile.profile_pic_only
+        download_posts = not (args.profile.no_posts or args.profile.stories_only or args.profile.profile_pic_only)
+        download_stories = args.profile.stories or args.profile.stories_only
 
-        loader = Instaloader(sleep=not args.no_sleep, quiet=args.quiet, user_agent=args.user_agent,
-                             dirname_pattern=args.dirname_pattern, filename_pattern=args.filename_pattern,
-                             download_pictures=not args.no_pictures,
-                             download_videos=not args.no_videos, download_video_thumbnails=not args.no_video_thumbnails,
-                             download_geotags=args.geotags,
-                             download_comments=args.comments, save_metadata=not args.no_metadata_json,
-                             compress_json=not args.no_compress_json,
+        def path_to_str(path: Optional[Path]):
+            # Using Path instead of str brings benefits, user file dialog. However the original code still needs a str|None, hence we cast it back.
+            return path and str(path)
+
+        loader = Instaloader(sleep=not args.download.no_sleep, quiet=quiet, user_agent=args.download.user_agent,
+                             dirname_pattern=args.download.dirname_pattern, filename_pattern=args.download.filename_pattern,
+                             download_pictures=not args.post.no_pictures,
+                             download_videos=not args.post.no_videos, download_video_thumbnails=not args.post.no_video_thumbnails,
+                             download_geotags=args.post.geotags,
+                             download_comments=args.post.comments, save_metadata=not args.post.no_metadata_json,
+                             compress_json=not args.post.no_compress_json,
                              post_metadata_txt_pattern=post_metadata_txt_pattern,
                              storyitem_metadata_txt_pattern=storyitem_metadata_txt_pattern,
-                             max_connection_attempts=args.max_connection_attempts,
-                             request_timeout=args.request_timeout,
+                             max_connection_attempts=args.download.max_connection_attempts,
+                             request_timeout=args.download.request_timeout,
                              resume_prefix=resume_prefix,
-                             check_resume_bbd=not args.use_aged_resume_files,
-                             slide=args.slide,
-                             fatal_status_codes=args.abort_on,
-                             iphone_support=not args.no_iphone,
-                             title_pattern=args.title_pattern,
-                             sanitize_paths=args.sanitize_paths)
+                             check_resume_bbd=not args.download.use_aged_resume_files,
+                             slide=args.post.slide,
+                             fatal_status_codes=args.download.abort_on,
+                             iphone_support=not args.download.no_iphone,
+                             title_pattern=args.download.title_pattern,
+                             sanitize_paths=args.download.sanitize_paths)
+
         exit_code = _main(loader,
-                          args.profile,
-                          username=args.login.lower() if args.login is not None else None,
-                          password=args.password,
-                          sessionfile=args.sessionfile,
+                          args.targets,
+                          username=args.login.login.lower() if args.login.login is not None else None,
+                          password=args.login.password,
+                          sessionfile=path_to_str(args.login.sessionfile),
                           download_profile_pic=download_profile_pic,
                           download_posts=download_posts,
                           download_stories=download_stories,
-                          download_highlights=args.highlights,
-                          download_tagged=args.tagged,
-                          download_reels=args.reels,
-                          download_igtv=args.igtv,
-                          fast_update=args.fast_update,
-                          latest_stamps_file=args.latest_stamps,
-                          max_count=int(args.count) if args.count is not None else None,
-                          post_filter_str=args.post_filter,
-                          storyitem_filter_str=args.storyitem_filter,
-                          browser=args.load_cookies,
-                          cookiefile=args.cookiefile)
+                          download_highlights=args.profile.highlights,
+                          download_tagged=args.profile.tagged,
+                          download_reels=args.profile.reels,
+                          download_igtv=args.profile.igtv,
+                          fast_update=args.conditions.fast_update,
+                          latest_stamps_file=path_to_str(args.conditions.latest_stamps),
+                          max_count=int(args.conditions.count) if args.conditions.count is not None else None,
+                          post_filter_str=args.conditions.post_filter,
+                          storyitem_filter_str=args.conditions.storyitem_filter,
+                          browser=args.login.load_cookies,
+                          cookiefile=path_to_str(args.login.cookiefile))
+
         loader.close()
         if loader.has_stored_errors:
             exit_code = ExitCode.NON_FATAL_ERROR

--- a/instaloader/cli.py
+++ b/instaloader/cli.py
@@ -1,0 +1,269 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Annotated, Literal, Optional, TypeVar
+
+from mininterface import Optional, Tag, Validation
+from mininterface.tag.flag import Blank
+from tyro.conf import (DisallowNone, FlagCreatePairsOff, OmitArgPrefixes,
+                       Positional, arg, configure)
+
+from .instaloader import (get_default_session_filename,
+                          get_default_stamps_filename)
+from .instaloadercontext import default_user_agent
+
+T = TypeVar("T")
+NoHint = Annotated[T, arg(help_behavior_hint="")]
+
+
+@dataclass
+class PostDownloadOptions:
+    """
+    What to Download of each Post
+    """
+
+    slide: NoHint[Optional[str]] = None
+    """Set what image/interval of a sidecar you want to download."""
+
+    no_pictures: NoHint[bool] = False
+    """Do not download post pictures. Cannot be used together with --fast-update.
+    Implies --no-video-thumbnails, does not imply --no-videos.
+    """
+
+    no_videos: Annotated[bool, arg(aliases=["-V"], help_behavior_hint="")] = False
+    """Do not download videos."""
+
+    no_video_thumbnails: NoHint[bool] = False
+    """Do not download thumbnails of videos."""
+
+    geotags: Annotated[bool, arg(aliases=["-G"], help_behavior_hint="")] = False
+    """Download geotags when available. Geotags are stored as a text file with the location's name and a Google Maps link.
+    This requires an additional request to the Instagram server for each picture. Requires login.
+    """
+
+    comments: Annotated[bool, arg(aliases=["-C"], help_behavior_hint="")] = False
+    """Download and update comments for each post. Requires an additional request to the Instagram server for each post.
+    Disabled by default. Requires login.
+    """
+
+    no_captions: NoHint[bool] = False
+    """Do not create txt files."""
+
+    post_metadata_txt: NoHint[list[str]] = field(default_factory=list)
+    """Template to write in txt file for each Post."""
+
+    storyitem_metadata_txt: NoHint[list[str]] = field(default_factory=list)
+    """Template to write in txt file for each StoryItem."""
+
+    no_metadata_json: NoHint[bool] = False
+    """Do not create a JSON file containing the metadata of each post."""
+
+    no_compress_json: NoHint[bool] = False
+    """Do not xz compress JSON files, rather create pretty formatted JSONs."""
+
+
+@dataclass
+class ProfileDownloadOptions:
+    """
+    What to Download of each Profile
+    """
+
+    no_posts: NoHint[bool] = False
+    """Do not download regular posts."""
+
+    no_profile_pic: NoHint[bool] = False
+    """Do not download profile picture."""
+
+    stories: Annotated[NoHint[bool], arg(aliases=["-s"])] = False
+    """Also download stories of each profile that is downloaded. Requires login."""
+
+    highlights: NoHint[bool] = False
+    """Also download highlights of each profile that is downloaded. Requires login."""
+
+    tagged: NoHint[bool] = False
+    """Also download posts where each profile is tagged."""
+
+    reels: NoHint[bool] = False
+    """Also download Reels videos."""
+
+    igtv: NoHint[bool] = False
+    """Also download IGTV videos."""
+
+    stories_only: NoHint[bool] = False
+
+    profile_pic_only: Annotated[bool, arg(aliases=["-P"], help_behavior_hint="")] = (
+        False
+    )
+
+
+@dataclass
+class ConditionOptions:
+    """
+    Which Posts to Download
+    """
+
+    fast_update: Annotated[bool, arg(aliases=["-F"], help_behavior_hint="")] = False
+    """For each target, stop when encountering the first already-downloaded picture.
+    Recommended when you use Instaloader to update your personal Instagram archive.
+    """
+
+    latest_stamps: Annotated[
+        Blank[Path], Literal[Path(get_default_stamps_filename())]
+    ] = None
+    """Store the timestamps of latest media scraped for each profile.
+    Allows updating your personal Instagram archive even if you delete the destination directories.
+    """
+
+    post_filter: Annotated[
+        Optional[str], arg(aliases=["--only-if"], help_behavior_hint="")
+    ] = None
+    """Expression that, if given, must evaluate to True for each post to be downloaded.
+    Must be a syntactically valid python expression. Variables are evaluated to instaloader.Post attributes.
+    Example: --post-filter=viewer_has_liked.
+    """
+
+    storyitem_filter: NoHint[Optional[str]] = None
+    """Expression that, if given, must evaluate to True for each storyitem to be downloaded.
+    Must be a syntactically valid python expression. Variables are evaluated to instaloader.StoryItem attributes.
+    """
+
+    count: Annotated[Optional[str], arg(aliases=["-c"], help_behavior_hint="")] = None
+    """Do not attempt to download more than COUNT posts. Applies to #hashtag, %location_id, :feed, and :saved.
+    """
+
+
+@dataclass
+class LoginOptions:
+    """
+    Login (Download Private Profiles)
+
+    Instaloader can login to Instagram. This allows downloading private profiles.
+    To login, pass the --login option. Your session cookie (not your password!)
+    will be saved to a local file to be reused next time you want Instaloader
+    to login. Instead of --login, the --load-cookies option can be used to
+    import a session from a browser.
+    """
+
+    login: Annotated[Optional[str], arg(aliases=["-l"], help_behavior_hint="")] = None
+    """Login name (profile name) for your Instagram account."""
+
+    load_cookies: Annotated[
+        Optional[str], arg(aliases=["-b"], help_behavior_hint="")
+    ] = None
+    """Browser name to load cookies from Instagram."""
+
+    cookiefile: Annotated[
+        Optional[Path], arg(aliases=["-B"], help_behavior_hint="")
+    ] = None
+    """Cookie file of a profile to load cookies."""
+
+    sessionfile: Annotated[
+        Optional[Path],
+        arg(
+            aliases=["-f"],
+            help_behavior_hint="",
+            help=f"""Path for loading and storing session key file. Defaults to {get_default_session_filename("<login_name>")}.""",
+        ),
+    ] = None
+
+    password: Annotated[Optional[str], arg(aliases=["-p"], help_behavior_hint="")] = (
+        None
+    )
+    """Password for your Instagram account. Without this option, you'll be prompted interactively
+    if there is not yet a valid session file."""
+
+
+def http_status_check(codes: Tag[list[int] | None]):
+    if codes.val is None:
+        return True
+    for code in codes.val:
+        if not 100 <= code <= 599:
+            return f"Invalid HTTP status code: {code}"
+    return True
+
+
+@dataclass
+class DownloadOptions:
+    """
+    How to Download
+    """
+
+    dirname_pattern: NoHint[Optional[str]] = None
+    """Name of directory where to store posts. {profile} is replaced by the profile name, {target} is replaced
+    by the target you specified, i.e. either :feed, #hashtag or the profile name. Defaults to '{target}'.
+    """
+
+    filename_pattern: Annotated[Optional[str], arg(help_behavior_hint="")] = None
+    """Prefix of filenames for posts and stories, relative to the directory given with --dirname-pattern.
+    {profile} is replaced by the profile name, {target} is replaced by the target you specified.
+    Defaults to '{date_utc}_UTC'.
+    """
+
+    title_pattern: Annotated[Optional[str], arg(help_behavior_hint="")] = None
+    """Prefix of filenames for profile pics, hashtag profile pics, and highlight covers.
+    Defaults to '{date_utc}_UTC_{typename}' if --dirname-pattern contains '{target}' or '{dirname}',
+    or if --dirname-pattern is not specified. Otherwise defaults to
+    '{target}_{date_utc}_UTC_{typename}'.
+    """
+
+    resume_prefix: Annotated[Optional[str], arg(help_behavior_hint="")] = None
+    """Prefix for filenames that are used to save the information to resume an interrupted download."""
+
+    sanitize_paths: NoHint[bool] = False
+    """Sanitize paths so that resulting file and directory names are valid on both Windows and Unix."""
+
+    no_resume: NoHint[bool] = False
+    """Do not resume a previously-aborted download iteration, and do not save such information when interrupted."""
+
+    use_aged_resume_files: NoHint[bool] = False
+
+    user_agent: str = default_user_agent()
+    """User Agent to use for HTTP requests."""
+
+    no_sleep: Annotated[bool, arg(aliases=["-S"], help_behavior_hint="")] = False
+
+    max_connection_attempts: int = 3
+    """Maximum number of connection attempts until a request is aborted.
+    If a connection fails, it can be manually skipped by hitting CTRL+C. Set to 0 to retry infinitely.
+    """
+
+    request_timeout: float = 300.0
+    """Seconds to wait before timing out a connection request."""
+
+    abort_on: Annotated[
+        Optional[list[int]], arg(help_behavior_hint=""), Validation(http_status_check)
+    ] = None
+    """Comma-separated list of HTTP status codes that cause Instaloader to abort, bypassing all retry logic."""
+
+    no_iphone: NoHint[bool] = False
+    """Do not attempt to download iPhone version of images and videos."""
+
+
+@dataclass
+@configure(DisallowNone, FlagCreatePairsOff, OmitArgPrefixes)
+class Env:
+    """
+    Download pictures (or videos) along with their captions and other metadata from Instagram.
+    """
+
+    targets: Positional[list[str]]
+    """
+    Specify a list of targets. For each of these, Instaloader creates a folder
+    and downloads all posts. The following targets are supported.
+
+      * profile             Download profile. If an already-downloaded profile has been renamed, Instaloader automatically finds it by its unique ID and renames the folder likewise.
+      * @profile            Download all followees of profile. Requires login. Consider using :feed rather than @yourself.
+      * #hashtag            Download #hashtag.
+      * %location_id        Download %%location_id. Requires login.
+      * :feed               Download pictures from your feed. Requires login.
+      * :stories            Download the stories of your followees. Requires login.
+      * :saved              Download the posts that you marked as saved. Requires login.
+      * -- -shortcode       Download the post with the given shortcode
+      * filename.json[.xz]  Re-Download the given object.
+      * +args.txt           Read targets (and options) from given textfile.
+    """
+
+    post: PostDownloadOptions
+    profile: ProfileDownloadOptions
+    conditions: ConditionOptions
+    login: LoginOptions
+    download: DownloadOptions

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_version():
 if sys.version_info < (3, 9):
     sys.exit('Instaloader requires Python >= 3.9.')
 
-requirements = ['requests>=2.25']
+requirements = ['requests>=2.25', 'mininterface[basic]~=1.1']
 optional_requirements = {
     'browser_cookie3': ['browser_cookie3>=0.19.1'],
 }
@@ -46,7 +46,7 @@ setup(
                 'from Instagram.',
     long_description=open(os.path.join(SRC, 'README.rst')).read(),
     install_requires=requirements,
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     extras_require=optional_requirements,
     entry_points={'console_scripts': ['instaloader=instaloader.__main__:main']},
     zip_safe=False,
@@ -57,8 +57,7 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.9',
+        'Operating System :: OS Independent',        
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
My proposal is to implement miniterface, a versatile CLI and dialog toolkit. This gives us various advantages.

# Automatic GUI and colourful helps

If left empty, there is an automatic wizzard. Note the file-picker button.

```bash
$ instaloader
```
<img width="1043" height="323" alt="image" src="https://github.com/user-attachments/assets/23e99f5f-9290-4a00-b413-6c0bb1a3e808" />

```bash
$ instaloader --help
...
╭─ login options ────────────────────────────────────────────────────────────╮
│ Login (Download Private Profiles)                                          │
│ Instaloader can login to Instagram. This allows downloading private        │
│ profiles.                                                                  │
│ To login, pass the --login option. Your session cookie (not your           │
│ password!)                                                                 │
│ will be saved to a local file to be reused next time you want Instaloader  │
│ to login. Instead of --login, the --load-cookies option can be used to     │
│ import a session from a browser.                                           │
│ ────────────────────────────────────────────────────────────────────────── │
│ -l STR, --login STR     Login name (profile name) for your Instagram       │
│                         account.                                           │
│ -b STR, --load-cookies STR                                                 │
│                         Browser name to load cookies from Instagram.       │
│ -B PATH, --cookiefile PATH                                                 │
│                         Cookie file of a profile to load cookies.          │
│ -f PATH, --sessionfile PATH                                                │
│                         Path for loading and storing session key file.     │
│                         Defaults to                                        │
│                         /home/edvard/.config/instaloader/session-<login_na │
│                         me>.                                               │
│ -p STR, --password STR  Password for your Instagram account. Without this  │
│                         option, you'll be prompted interactively           │
│                         if there is not yet a valid session file.          │
╰────────────────────────────────────────────────────────────────────────────╯
...
```

# Automatic TUI

On machines without display (ex. through SSH), there is an automatic fallback for a mouse-clickable text interface.

```bash
$ instaloader
```

<img width="866" height="637" alt="image" src="https://github.com/user-attachments/assets/5b968c0e-3690-4c62-ac75-69816537cfde" />

# Transparent parser

Instead of the `argparse`, I've refactored the configuration to dataclasses.

So instead of this structure we have something more readable.

```python
g_prof = parser.add_argument_group("What to Download of each Profile")

g_prof.add_argument('-P', '--profile-pic-only', action='store_true',
                    help=SUPPRESS)
g_prof.add_argument('--no-posts', action='store_true',
                    help="Do not download regular posts.")
g_prof.add_argument('--no-profile-pic', action='store_true',
                    help='Do not download profile picture.')                        
g_prof.add_argument('-s', '--stories', action='store_true',
                    help='Also download stories of each profile that is downloaded. Requires login.')
g_prof.add_argument('--stories-only', action='store_true',
                    help=SUPPRESS)
g_prof.add_argument('--highlights', action='store_true',
                    help='Also download highlights of each profile that is downloaded. Requires login.')
g_prof.add_argument('--tagged', action='store_true',
                    help='Also download posts where each profile is tagged.')
g_prof.add_argument('--reels', action='store_true',
                    help='Also download Reels videos.')
g_prof.add_argument('--igtv', action='store_true',
                    help='Also download IGTV videos.')
```

The dataclass mentioned:

```python
@dataclass
class ProfileDownloadOptions:
    """
    What to Download of each Profile
    """

    no_posts: NoHint[bool] = False
    """Do not download regular posts."""

    no_profile_pic: NoHint[bool] = False
    """Do not download profile picture."""

    stories: Annotated[NoHint[bool], arg(aliases=["-s"])] = False
    """Also download stories of each profile that is downloaded. Requires login."""

    highlights: NoHint[bool] = False
    """Also download highlights of each profile that is downloaded. Requires login."""

    tagged: NoHint[bool] = False
    """Also download posts where each profile is tagged."""

    reels: NoHint[bool] = False
    """Also download Reels videos."""

    igtv: NoHint[bool] = False
    """Also download IGTV videos."""

    stories_only: NoHint[bool] = False

    profile_pic_only: Annotated[bool, arg(aliases=["-P"], help_behavior_hint="")] = (
        False
    )
```

# IDE benefits

The miniterface would have worked with our argparse too but refactoring into dataclasses will give us benefits. Automatic type control, IDE suggestions and IDE is now able to show hints (which is impossible with the old `argparse`).

<img width="513" height="164" alt="image" src="https://github.com/user-attachments/assets/61719708-d358-4954-abaa-92e20ff3e3a5" />

Also, it allows us a direct usage of complex types instead of the basic ones the `arpgarse` supports. It works well with `Enums`, `Paths`, dates, etc.

# Conclusion

The functionality is equal. Are you interested in this PR, what do you think? Are there any changes I should catch up?

> Is it just a proof of concept?

No, it works.

> Is the documentation updated (if appropriate)?

Whether you say yes to the PR, I do any changes, refactor to other tag, etc...

> Do you consider it ready to be merged or is it a draft?

Working draft for your evaluation.
