### PR TITLE
Handle substantional Instagram requirements

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -395,8 +395,10 @@ class InstaloaderContext:
         :param session: Session to use, or None to use self.session
         :param use_post: Use POST instead of GET to make the request
         :return: Decoded response dictionary
-        :raises AbortDownloadException: When the server responds with 'feedback_required'/'checkpoint_required'/'challenge_required'
-        :raises QueryReturnedBadRequestException: When the server responds with a 400 (and not 'feedback_required'/'checkpoint_required'/'challenge_required').
+        :raises AbortDownloadException: When the server responds with
+            'feedback_required'/'checkpoint_required'/'challenge_required'
+        :raises QueryReturnedBadRequestException: When the server responds with a 400 (and not
+            'feedback_required'/'checkpoint_required'/'challenge_required').
         :raises QueryReturnedNotFoundException: When the server responds with a 404.
         :raises ConnectionException: When query repeatedly failed.
 


### PR DESCRIPTION
When Instagram returns "feedback_required", "checkpoint_required" or "challenge_required", any further requests will be declined until the required action is performed manually. Those messages mean Instagram suspects us of being a bot, so we must stop producing more requests immediately in order not to increase the suspicions.

This PR makes get_json (the status_code 400 block) raise AbortDownloadException with a detailed explanation for Instagram "feedback_required"/"checkpoint_required"/"challenge_required" responses.

I've updated get_json's docstring, but the documentation may need to be rerendered.

Generally, the PR's (almost?) ready to be merged.

I would appreciate a review and some help with docs (if there's something else to be done). You should be able to make edits directly to my branch.