### PR TITLE
Fix: --count option for profile targets

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -311,6 +311,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
             post_filter,
             storyitem_filter,
             latest_stamps=latest_stamps,
+            max_count=max_count,
             reels=download_reels,
         )
         if anonymous_retry_profiles:
@@ -453,7 +454,7 @@ def main():
 
     g_cond.add_argument('-c', '--count',
                         help='Do not attempt to download more than COUNT posts. '
-                             'Applies to #hashtag, %%location_id, :feed, and :saved.')
+                             'Applies to #hashtag, %%location_id, :feed, :saved and profile')
 
     g_login = parser.add_argument_group('Login (Download Private Profiles)',
                                         'Instaloader can login to Instagram. This allows downloading private profiles. '


### PR DESCRIPTION
# Fix --count option for profile targets

## Summary

This PR fixes the `--count` option to work with profile targets (e.g., `instaloader --count 1 profile`). Previously, the `--count` option only worked for hashtags, locations, feeds, and saved posts, but not for regular profiles.

## Problem

The `--count` CLI option should limit the number of posts downloaded, but it wasn't working for profile targets. Running `instaloader --count 1 instagram` would download all available posts instead of stopping at 1.

```bash
instaloader --count 1 instagram
...
Retrieving posts from profile instagram.
[   1/8256]
```

## Solution

Added the missing `max_count=max_count` parameter to `download_profiles()` in `__main__.py`. The `download_profiles()` function already supported this parameter, but it wasn't being passed from the CLI.

```bash
instaloader --count 1 instagram
...
Retrieving posts from profile instagram.
[1/1]
```
