### PR TITLE
Add progress counter to "Retrieving highlights" log line

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -961,9 +961,9 @@ class Instaloader:
            Also downloads and saves the Highlight's cover pictures.
 
         .. versionchanged:: 4.16
-        Add progress output for highlight retrieval, displaying a counter of the current
-        highlight number and the total number of highlights being processed. This provides
-        feedback similar to the per-item download counter already present in this function.
+           Add progress output for highlight retrieval, displaying a counter of the current
+           highlight number and the total number of highlights being processed. This provides
+           feedback similar to the per-item download counter already present in this function.
 
         :param user: ID or Profile of the user whose highlights should get downloaded.
         :param fast_update: If true, abort when first already-downloaded picture is encountered


### PR DESCRIPTION
Fixes: #2620 

When downloading highlights, Instaloader prints the message “Retrieving highlights …” but without any progress indicator.  This makes it hard for the user to know which highlight is currently  being processed or how many remain.

This change adds a progress counter in the same line, using the same  [%3i/%3i] format already used in story item downloads.  The goal is to make the output clearer and more consistent.

**Changes proposed**

- Add a counter to the log printed before downloading each highlight.
- Combine the counter and the retrieval message into a single line.
- No behavior, API, or download logic is modified — only console output.


**Completeness**

- This is a small, focused enhancement.
- Tested locally with: `python instaloader.py +args.txt`
- No documentation updates needed because this only affects logging.
- Ready to be reviewed and merged.

---
### Contents of args.txt
```
--login=myuser
--dirname-pattern=./tmp/{target}
--no-captions
--no-video-thumbnails
--no-metadata-json
--no-compress-json
--no-profile-pic
--no-posts
--highlights
--sanitize-paths
willsmith

```

---
### Execution result
```
[1/1] Downloading profile willsmith
Retrieving highlights [  1/ 14] "TOUR" from profile willsmith
...
Retrieving highlights [  2/ 14] "Freestyles" from profile willsmith
...
Retrieving highlights [  3/ 14] "Cliff Top" from profile willsmith
...
Retrieving highlights [  4/ 14] "Good v Great" from profile willsmith
...
Retrieving highlights [  5/ 14] "Mind" from profile willsmith
...
Retrieving highlights [  6/ 14] "Belief" from profile willsmith
...
Retrieving highlights [  7/ 14] "Love" from profile willsmith
...
Retrieving highlights [  8/ 14] "Flames" from profile willsmith
...
Retrieving highlights [  9/ 14] "Likes/Dislikes" from profile willsmith
...
Retrieving highlights [ 10/ 14] "Self Love" from profile willsmith
...
Retrieving highlights [ 11/ 14] "Discipline" from profile willsmith
...
Retrieving highlights [ 12/ 14] "Happiness" from profile willsmith
...
Retrieving highlights [ 13/ 14] "Fault" from profile willsmith
...
Retrieving highlights [ 14/ 14] "Failure" from profile willsmith
...

```