### PR TITLE
Fix Profile API by migrating to GraphQL endpoints

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -909,10 +909,22 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
-        # pylint:disable=protected-access
-        profile = cls(context, {'username': username.lower()})
-        profile._obtain_metadata()  # to raise ProfileNotExistsException now in case username is invalid
-        return profile
+        variables = {
+            "data": {
+                "count": 12
+            },
+            "username": username,
+            "__relay_internal__pv__PolarisFeedShareMenurelayprovider": False,
+        }
+        data = context.doc_id_graphql_query('7898261790222653', variables)
+        try:
+            user_info = data["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"]["edges"][0]["node"]["user"]
+            profile = cls(context, user_info)
+            profile._obtain_metadata()
+            return profile
+        except Exception as e:
+            raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
+                                            str(username) + ").") from e
 
     @classmethod
     def from_id(cls, context: InstaloaderContext, profile_id: int):
@@ -979,11 +991,23 @@ class Profile:
     def _obtain_metadata(self):
         try:
             if not self._has_full_metadata:
-                metadata = self._context.get_iphone_json(f'api/v1/users/web_profile_info/?username={self.username}',
-                                                         params={})
-                if metadata['data']['user'] is None:
+                user_id = self._node.get('id') or self._node.get('pk')
+                if not user_id:
+                    raise ProfileNotExistsException('Profile {} has no user ID.'.format(self.username))
+                variables = {
+                    "id": str(user_id),
+                    "render_surface": "PROFILE",
+                    "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
+                    "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
+                    "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
+                }
+                data = self._context.doc_id_graphql_query('25980296051578533', variables)
+                if data is None:
+                    raise QueryReturnedNotFoundException('GraphQL query returned None')
+                user_data = data.get('data', {}).get('user')
+                if user_data is None:
                     raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
-                self._node = metadata['data']['user']
+                self._node = self._normalize_profile_data(user_data)
                 self._has_full_metadata = True
         except (QueryReturnedNotFoundException, KeyError) as err:
             top_search_results = TopSearchResults(self._context, self.username)
@@ -997,6 +1021,44 @@ class Profile:
                                                         's are' if len(similar_profiles) > 1 else ' is',
                                                         ', '.join(similar_profiles[0:5]))) from err
             raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username)) from err
+
+    def _normalize_profile_data(self, user_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize PolarisProfilePageContentQuery response to match legacy format."""
+        normalized = user_data.copy()
+        if 'id' not in normalized and 'pk' in normalized:
+            normalized['id'] = normalized['pk']
+        if 'edge_owner_to_timeline_media' not in normalized and 'media_count' in normalized:
+            normalized['edge_owner_to_timeline_media'] = {'count': normalized['media_count']}
+        if 'edge_felix_video_timeline' not in normalized:
+            normalized['edge_felix_video_timeline'] = {'count': 0}
+        if 'edge_followed_by' not in normalized and 'follower_count' in normalized:
+            normalized['edge_followed_by'] = {'count': normalized['follower_count']}
+        if 'edge_follow' not in normalized and 'following_count' in normalized:
+            normalized['edge_follow'] = {'count': normalized['following_count']}
+        if 'is_business_account' not in normalized and 'is_business' in normalized:
+            normalized['is_business_account'] = normalized['is_business']
+        if 'business_category_name' not in normalized and 'category' in normalized:
+            normalized['business_category_name'] = normalized['category']
+        friendship = normalized.get('friendship_status', {}) or {}
+        if 'followed_by_viewer' not in normalized:
+            normalized['followed_by_viewer'] = friendship.get('followed_by', False)
+        if 'follows_viewer' not in normalized:
+            normalized['follows_viewer'] = friendship.get('following', False)
+        if 'blocked_by_viewer' not in normalized:
+            normalized['blocked_by_viewer'] = friendship.get('blocking', False)
+        if 'has_blocked_viewer' not in normalized:
+            normalized['has_blocked_viewer'] = False
+        if 'has_requested_viewer' not in normalized:
+            normalized['has_requested_viewer'] = friendship.get('incoming_request', False)
+        if 'requested_by_viewer' not in normalized:
+            normalized['requested_by_viewer'] = friendship.get('outgoing_request', False)
+        if 'profile_pic_url_hd' not in normalized:
+            hd_info = normalized.get('hd_profile_pic_url_info')
+            if hd_info and 'url' in hd_info:
+                normalized['profile_pic_url_hd'] = hd_info['url']
+            elif 'profile_pic_url' in normalized:
+                normalized['profile_pic_url_hd'] = normalized['profile_pic_url']
+        return normalized
 
     def _metadata(self, *keys) -> Any:
         try:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -909,22 +909,6 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
-        variables = {
-            "data": {
-                "count": 12
-            },
-            "username": username,
-            "__relay_internal__pv__PolarisFeedShareMenurelayprovider": False,
-        }
-        data = context.doc_id_graphql_query('7898261790222653', variables)
-        try:
-            user_info = data["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"]["edges"][0]["node"]["user"]
-            profile = cls(context, user_info)
-            profile._obtain_metadata()
-            return profile
-        except (KeyError, IndexError):
-            pass
-
         for profile in TopSearchResults(context, username).get_profiles():
             if profile.username == username:
                 profile._obtain_metadata()

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -889,7 +889,8 @@ class Profile:
     Also, this class implements == and is hashable.
     """
     def __init__(self, context: InstaloaderContext, node: Dict[str, Any]):
-        assert 'username' in node
+        assert "username" in node
+        assert "id" in node or "pk" in node
         self._context = context
         self._has_public_story: Optional[bool] = None
         self._node = node
@@ -909,33 +910,28 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
-        for profile in TopSearchResults(context, username).get_profiles():
-            if profile.username.lower() == username.lower():
-                profile._obtain_metadata()
-                return profile
 
-        variables = {
-            "data": {
-                "count":12,
-                "include_reel_media_seen_timestamp": False,
-                "include_relationship_info": True,
-                "latest_besties_reel_media": False,
-                "latest_reel_media": False
+        data = context.doc_id_graphql_query(
+            "34579740524958711",
+            {
+                "data": {
+                    "count": 12,
+                    "include_reel_media_seen_timestamp": False,
+                    "include_relationship_info": True,
+                    "latest_besties_reel_media": False,
+                    "latest_reel_media": False,
+                },
+                "username": username,
             },
-            "username":username
-        }
+        )
 
-        data = context.doc_id_graphql_query('34579740524958711', variables)
         try:
             user_info = data["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"]["edges"][0]["node"]["user"]
             profile = cls(context, user_info)
-            profile._obtain_metadata()
-            return profile
-        except (KeyError, IndexError):
-            pass
+        except (TypeError, IndexError) as exc:
+            raise ProfileNotExistsException("Profile {} does not exist.".format(username)) from exc
 
-        raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
-                                        str(username) + ").")
+        return profile
 
     @classmethod
     def from_id(cls, context: InstaloaderContext, profile_id: int):
@@ -1003,8 +999,6 @@ class Profile:
         try:
             if not self._has_full_metadata:
                 user_id = self._node.get('id') or self._node.get('pk')
-                if not user_id:
-                    raise ProfileNotExistsException('Profile {} has no user ID.'.format(self.username))
                 variables = {
                     "id": str(user_id),
                     "render_surface": "PROFILE",

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -911,27 +911,12 @@ class Profile:
         :raises: :class:`ProfileNotExistsException`
         """
 
-        data = context.doc_id_graphql_query(
-            "34579740524958711",
-            {
-                "data": {
-                    "count": 12,
-                    "include_reel_media_seen_timestamp": False,
-                    "include_relationship_info": True,
-                    "latest_besties_reel_media": False,
-                    "latest_reel_media": False,
-                },
-                "username": username,
-            },
-        )
-
-        try:
-            user_info = data["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"]["edges"][0]["node"]["user"]
-            profile = cls(context, user_info)
-        except (TypeError, IndexError) as exc:
-            raise ProfileNotExistsException("Profile {} does not exist.".format(username)) from exc
-
-        return profile
+        data = context.doc_id_graphql_query("26347858941511777", {"hasQuery": True, "query": username})
+        for user in data["data"]["xdt_api__v1__fbsearch__non_profiled_serp"]["users"]:
+            if user["username"].lower() == username.lower():
+                return cls(context, user)
+        else:
+            raise ProfileNotExistsException("Profile {} does not exist.".format(username))
 
     @classmethod
     def from_id(cls, context: InstaloaderContext, profile_id: int):

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -914,6 +914,26 @@ class Profile:
                 profile._obtain_metadata()
                 return profile
 
+        variables = {
+            "data": {
+                "count":12,
+                "include_reel_media_seen_timestamp": False,
+                "include_relationship_info": True,
+                "latest_besties_reel_media": False,
+                "latest_reel_media": False
+            },
+            "username":username
+        }
+
+        data = context.doc_id_graphql_query('34579740524958711', variables)
+        try:
+            user_info = data["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"]["edges"][0]["node"]["user"]
+            profile = cls(context, user_info)
+            profile._obtain_metadata()
+            return profile
+        except (KeyError, IndexError):
+            pass
+
         raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
                                         str(username) + ").")
 

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -910,7 +910,7 @@ class Profile:
         :raises: :class:`ProfileNotExistsException`
         """
         for profile in TopSearchResults(context, username).get_profiles():
-            if profile.username == username:
+            if profile.username.lower() == username.lower():
                 profile._obtain_metadata()
                 return profile
 

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -922,9 +922,16 @@ class Profile:
             profile = cls(context, user_info)
             profile._obtain_metadata()
             return profile
-        except Exception as e:
-            raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
-                                            str(username) + ").") from e
+        except (KeyError, IndexError):
+            pass
+
+        for profile in TopSearchResults(context, username).get_profiles():
+            if profile.username == username:
+                profile._obtain_metadata()
+                return profile
+
+        raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
+                                        str(username) + ").")
 
     @classmethod
     def from_id(cls, context: InstaloaderContext, profile_id: int):

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1048,9 +1048,9 @@ class Profile:
             normalized['business_category_name'] = normalized['category']
         friendship = normalized.get('friendship_status', {}) or {}
         if 'followed_by_viewer' not in normalized:
-            normalized['followed_by_viewer'] = friendship.get('followed_by', False)
+            normalized['followed_by_viewer'] = friendship.get('following', False)
         if 'follows_viewer' not in normalized:
-            normalized['follows_viewer'] = friendship.get('following', False)
+            normalized['follows_viewer'] = friendship.get('followed_by', False)
         if 'blocked_by_viewer' not in normalized:
             normalized['blocked_by_viewer'] = friendship.get('blocking', False)
         if 'has_blocked_viewer' not in normalized:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -910,13 +910,13 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
+        data = context.doc_id_graphql_query("26347858941511777", {"hasQuery": True, "query": username})["data"]
+        if data:
+            for user in data["xdt_api__v1__fbsearch__non_profiled_serp"]["users"]:
+                if user["username"].lower() == username.lower():
+                    return cls(context, user)
 
-        data = context.doc_id_graphql_query("26347858941511777", {"hasQuery": True, "query": username})
-        for user in data["data"]["xdt_api__v1__fbsearch__non_profiled_serp"]["users"]:
-            if user["username"].lower() == username.lower():
-                return cls(context, user)
-        else:
-            raise ProfileNotExistsException("Profile {} does not exist.".format(username))
+        raise ProfileNotExistsException("Profile {} does not exist.".format(username))
 
     @classmethod
     def from_id(cls, context: InstaloaderContext, profile_id: int):


### PR DESCRIPTION
## Summary

Fixes #2651 - Resolves persistent 429 errors and "useragent mismatch" issues when fetching profile data by migrating from the deprecated `web_profile_info` API to GraphQL endpoints.

## Problem

The `web_profile_info` API endpoint has become unreliable, frequently returning:
- 429 Too Many Requests
- "useragent mismatch" errors
- Inconsistent behavior even with valid sessions

This affects `Profile.from_username()` and `Profile._obtain_metadata()`, blocking basic profile operations.

## Solution

- **`Profile.from_username()`**: Now uses `TopSearchResults` to fetch profile data, with fallback to GraphQL doc_id `34579740524958711` (PolarisProfilePostsQuery) for short usernames that may not appear in search results
- **`Profile._obtain_metadata()`**: Now uses GraphQL doc_id `25980296051578533` (PolarisProfilePageContentQuery) to fetch profile metadata
- Added `_normalize_profile_data()` to map new API response structure to existing Profile fields
- Maintains backward compatibility with existing code

## Testing

⚠️ **This fix requires authenticated sessions to work reliably.**

Tested with authenticated session:
- Public profile post downloads
- Public profile story downloads

Additional testing on edge cases (private profiles, profiles without posts, etc.) would be appreciated.

## Breaking Changes

None. The changes are internal API migrations that maintain the existing public interface.