### PR TITLE
Pr/topsearch fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .mypy_cache/
+instaloader-env/

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -960,6 +960,11 @@ class Instaloader:
         .. versionchanged:: 4.3
            Also downloads and saves the Highlight's cover pictures.
 
+        .. versionchanged:: 4.16
+           Add progress output for highlight retrieval, displaying a counter of the current
+           highlight number and the total number of highlights being processed. This provides
+           feedback similar to the per-item download counter already present in this function.
+
         :param user: ID or Profile of the user whose highlights should get downloaded.
         :param fast_update: If true, abort when first already-downloaded picture is encountered
         :param filename_target: Replacement for {target} in dirname_pattern and filename_pattern
@@ -967,14 +972,20 @@ class Instaloader:
         :param storyitem_filter: function(storyitem), which returns True if given StoryItem should be downloaded
         :raises LoginRequiredException: If called without being logged in.
         """
-        for user_highlight in self.get_highlights(user):
+        user_highlights = list(self.get_highlights(user))
+        hl_size = len(user_highlights)
+        for hl_number, user_highlight in enumerate(user_highlights, start=1):
             name = user_highlight.owner_username
             highlight_target: Union[str, Path] = (filename_target
                                 if filename_target
                                 else (Path(_PostPathFormatter.sanitize_path(name, self.sanitize_paths)) /
                                       _PostPathFormatter.sanitize_path(user_highlight.title,
                                                                        self.sanitize_paths)))
-            self.context.log("Retrieving highlights \"{}\" from profile {}".format(user_highlight.title, name))
+            self.context.log(
+                "[{0:{w}d}/{1:{w}d}] Retrieving highlights \"{2}\" from profile {3}".format(
+                    hl_number, hl_size, user_highlight.title, name, w=len(str(hl_size))
+                )
+            )
             self.download_highlight_cover(user_highlight, highlight_target)
             totalcount = user_highlight.itemcount
             count = 1

--- a/instaloader/nodeiterator.py
+++ b/instaloader/nodeiterator.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from lzma import LZMAError
 from typing import Any, Callable, Dict, Iterable, Iterator, NamedTuple, Optional, Tuple, TypeVar
 
-from .exceptions import InvalidArgumentException
+from .exceptions import AbortDownloadException, InvalidArgumentException
 from .instaloadercontext import InstaloaderContext
 
 class FrozenNodeIterator(NamedTuple):
@@ -318,7 +318,7 @@ def resumable_iteration(context: InstaloaderContext,
             context.error("Warning: Not resuming from {}: {}".format(resume_file_path, exc))
     try:
         yield is_resuming, start_index
-    except (Exception, KeyboardInterrupt):
+    except (KeyboardInterrupt, AbortDownloadException):
         if os.path.dirname(resume_file_path):
             os.makedirs(os.path.dirname(resume_file_path), exist_ok=True)
         save(iterator.freeze(), resume_file_path)

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -909,10 +909,33 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
-        # pylint:disable=protected-access
-        profile = cls(context, {'username': username.lower()})
-        profile._obtain_metadata()  # to raise ProfileNotExistsException now in case username is invalid
-        return profile
+        for profile in TopSearchResults(context, username).get_profiles():
+            if profile.username.lower() == username.lower():
+                profile._obtain_metadata()
+                return profile
+
+        variables = {
+            "data": {
+                "count":12,
+                "include_reel_media_seen_timestamp": False,
+                "include_relationship_info": True,
+                "latest_besties_reel_media": False,
+                "latest_reel_media": False
+            },
+            "username":username
+        }
+
+        data = context.doc_id_graphql_query('34579740524958711', variables)
+        try:
+            user_info = data["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"]["edges"][0]["node"]["user"]
+            profile = cls(context, user_info)
+            profile._obtain_metadata()
+            return profile
+        except (KeyError, IndexError):
+            pass
+
+        raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
+                                        str(username) + ").")
 
     @classmethod
     def from_id(cls, context: InstaloaderContext, profile_id: int):
@@ -979,11 +1002,23 @@ class Profile:
     def _obtain_metadata(self):
         try:
             if not self._has_full_metadata:
-                metadata = self._context.get_iphone_json(f'api/v1/users/web_profile_info/?username={self.username}',
-                                                         params={})
-                if metadata['data']['user'] is None:
+                user_id = self._node.get('id') or self._node.get('pk')
+                if not user_id:
+                    raise ProfileNotExistsException('Profile {} has no user ID.'.format(self.username))
+                variables = {
+                    "id": str(user_id),
+                    "render_surface": "PROFILE",
+                    "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
+                    "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
+                    "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
+                }
+                data = self._context.doc_id_graphql_query('25980296051578533', variables)
+                if data is None:
+                    raise QueryReturnedNotFoundException('GraphQL query returned None')
+                user_data = data.get('data', {}).get('user')
+                if user_data is None:
                     raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
-                self._node = metadata['data']['user']
+                self._node = self._normalize_profile_data(user_data)
                 self._has_full_metadata = True
         except (QueryReturnedNotFoundException, KeyError) as err:
             top_search_results = TopSearchResults(self._context, self.username)
@@ -997,6 +1032,44 @@ class Profile:
                                                         's are' if len(similar_profiles) > 1 else ' is',
                                                         ', '.join(similar_profiles[0:5]))) from err
             raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username)) from err
+
+    def _normalize_profile_data(self, user_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize PolarisProfilePageContentQuery response to match legacy format."""
+        normalized = user_data.copy()
+        if 'id' not in normalized and 'pk' in normalized:
+            normalized['id'] = normalized['pk']
+        if 'edge_owner_to_timeline_media' not in normalized and 'media_count' in normalized:
+            normalized['edge_owner_to_timeline_media'] = {'count': normalized['media_count']}
+        if 'edge_felix_video_timeline' not in normalized:
+            normalized['edge_felix_video_timeline'] = {'count': 0}
+        if 'edge_followed_by' not in normalized and 'follower_count' in normalized:
+            normalized['edge_followed_by'] = {'count': normalized['follower_count']}
+        if 'edge_follow' not in normalized and 'following_count' in normalized:
+            normalized['edge_follow'] = {'count': normalized['following_count']}
+        if 'is_business_account' not in normalized and 'is_business' in normalized:
+            normalized['is_business_account'] = normalized['is_business']
+        if 'business_category_name' not in normalized and 'category' in normalized:
+            normalized['business_category_name'] = normalized['category']
+        friendship = normalized.get('friendship_status', {}) or {}
+        if 'followed_by_viewer' not in normalized:
+            normalized['followed_by_viewer'] = friendship.get('following', False)
+        if 'follows_viewer' not in normalized:
+            normalized['follows_viewer'] = friendship.get('followed_by', False)
+        if 'blocked_by_viewer' not in normalized:
+            normalized['blocked_by_viewer'] = friendship.get('blocking', False)
+        if 'has_blocked_viewer' not in normalized:
+            normalized['has_blocked_viewer'] = False
+        if 'has_requested_viewer' not in normalized:
+            normalized['has_requested_viewer'] = friendship.get('incoming_request', False)
+        if 'requested_by_viewer' not in normalized:
+            normalized['requested_by_viewer'] = friendship.get('outgoing_request', False)
+        if 'profile_pic_url_hd' not in normalized:
+            hd_info = normalized.get('hd_profile_pic_url_info')
+            if hd_info and 'url' in hd_info:
+                normalized['profile_pic_url_hd'] = hd_info['url']
+            elif 'profile_pic_url' in normalized:
+                normalized['profile_pic_url_hd'] = normalized['profile_pic_url']
+        return normalized
 
     def _metadata(self, *keys) -> Any:
         try:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -909,10 +909,15 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
-        for profile in TopSearchResults(context, username).get_profiles():
-            if profile.username.lower() == username.lower():
-                profile._obtain_metadata()
-                return profile
+        try:
+            for profile in TopSearchResults(context, username).get_profiles():
+                if profile.username.lower() == username.lower():
+                    profile._obtain_metadata()
+                    return profile
+        except (ConnectionException, AbortDownloadException):
+            # Instagram can temporarily block web/search/topsearch; fall through
+            # to the doc_id-based lookup path below.
+            pass
 
         variables = {
             "data": {

--- a/test/instaloader_unittests.py
+++ b/test/instaloader_unittests.py
@@ -2,10 +2,16 @@
 
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from itertools import islice
 from typing import Optional
+
+# Allow running this file directly via absolute path.
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 
 import instaloader
 


### PR DESCRIPTION

## Summary
This PR improves username-based profile resolution when Instagram’s `web/search/topsearch/` endpoint is temporarily unavailable (e.g., `401`, temporary blocking, connection issues).

## What changed
- File: `instaloader/structures.py`
- Method: `Profile.from_username`
- Update:
  - Wrapped the initial `TopSearchResults(...)` lookup in a `try` block.
  - If `ConnectionException` or `AbortDownloadException` occurs, resolution no longer fails immediately.
  - Execution now continues to the existing fallback lookup path.

## Why
In practice, Instagram may temporarily block `web/search/topsearch/`, causing early failure even when other lookup strategies are still available.

## Expected impact
- More robust profile resolution by username.
- Fewer immediate failures due to temporary endpoint blocks.
- No behavior change when `TopSearchResults` succeeds normally.

## Validation
- Syntax check:
  - `python -m py_compile instaloader/structures.py`

