### PR TITLE
Auto-disable iPhone API after 403 to avoid per-post retry penalty

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -651,7 +651,14 @@ class InstaloaderContext:
                 tempsession.cookies.clear()
 
             response_headers = dict()    # type: Dict[str, Any]
-            response = self.get_json(path, params, 'i.instagram.com', tempsession, response_headers=response_headers)
+            try:
+                response = self.get_json(path, params, 'i.instagram.com', tempsession,
+                                         response_headers=response_headers)
+            except (ConnectionException, LoginRequiredException) as err:
+                if '403' in str(err):
+                    self.iphone_support = False
+                    self.error("iPhone API returned 403. Disabling iPhone API for this session.")
+                raise
 
             # Extract the ig-set-* headers and use them in the next request
             for key, value in response_headers.items():


### PR DESCRIPTION
Fixes #2661

## Summary

When `get_iphone_json()` encounters a 403 response, set `self.iphone_support = False` so that subsequent posts skip the iPhone API entirely instead of retrying `max_connection_attempts` times per post.

## The problem

If a session can't access the iPhone API (`i.instagram.com`), every post triggers the full retry cycle:

- Post 1: 3 retries with sleeps → `ConnectionException` → fallback to CDN
- Post 2: 3 retries with sleeps → `ConnectionException` → fallback to CDN
- ...repeat for every post

For a 200-post profile with `max_connection_attempts=3`, that's ~600 wasted requests with rate-limit delays between each. Downloads appear to hang with no explanation.

## The fix

4 lines in `get_iphone_json()`:

```python
try:
    response = self.get_json(path, params, 'i.instagram.com', ...)
except (ConnectionException, LoginRequiredException) as err:
    if '403' in str(err):
        self.iphone_support = False
        self.error("iPhone API returned 403. Disabling iPhone API for this session.")
    raise
```

All callers in `structures.py` already check `context.iphone_support` before calling iPhone API (e.g., `Post.url` line 430: `if self._context.iphone_support and self._context.is_logged_in`), so flipping the flag to `False` is sufficient — subsequent posts skip the iPhone API path entirely and use CDN URLs directly.

## Before / After

| | Before | After |
|---|---|---|
| 200-post profile with 403 | ~600 failed requests + sleeps | 1 failed request, then CDN fallback |
| Users without 403 | No change | No change |
| `--no-iphone` flag | Still works | Still works (manual override) |

## Design notes

- Complements the existing `--no-iphone` flag (manual opt-out) with automatic detection (graceful degradation)
- Uses `self.error()` for the log message, consistent with how instaloader reports errors elsewhere
- The current call still raises (callers already handle fallback), only future calls are skipped
- Zero behavior change for sessions that don't encounter 403s