### PR TITLE
Fix get_posts() — replace revoked doc_id 7898261790222653 with 34579740524958711

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1206,33 +1206,26 @@ class Profile:
 
         :rtype: NodeIterator[Post]"""
         self._obtain_metadata()
-        logged_in = self._context.is_logged_in
+        # doc_id 7898261790222653 was revoked by Instagram (returns 401 for all users).
+        # Use 34579740524958711 instead — same fix approach as PR #2652.
         return NodeIterator(
             context=self._context,
-            edge_extractor=(
-                (lambda d: d["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"])
-                if logged_in
-                else (lambda d: d["data"]["user"]["edge_owner_to_timeline_media"])
-            ),
-            node_wrapper=(
-                (lambda n: Post.from_iphone_struct(self._context, n))
-                if logged_in
-                else (lambda n: Post(self._context, n, self))
-            ),
+            edge_extractor=lambda d: d["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"],
+            node_wrapper=lambda n: Post.from_iphone_struct(self._context, n),
             query_variables={
                 "data": {
                     "count": 12,
+                    "include_reel_media_seen_timestamp": False,
                     "include_relationship_info": True,
-                    "latest_besties_reel_media": True,
-                    "latest_reel_media": True,
+                    "latest_besties_reel_media": False,
+                    "latest_reel_media": False,
                 },
-                **({"username": self.username} if logged_in else {"id": self.userid}),
+                "username": self.username,
             },
             query_referer="https://www.instagram.com/{0}/".format(self.username),
             is_first=Profile._make_is_newest_checker(),
-            doc_id="7898261790222653" if logged_in else "7950326061742207",
+            doc_id="34579740524958711",
             query_hash=None,
-            first_data=(None if logged_in else self._metadata("edge_owner_to_timeline_media")),
         )
 
     def get_saved_posts(self) -> NodeIterator[Post]:


### PR DESCRIPTION
## Problem

\`Profile.get_posts()\` is broken for all users globally. The \`doc_id=7898261790222653\` used for the logged-in path returns \`401 Unauthorized - "Please wait a few minutes before you try again."\` regardless of session validity, IP address, or account.

Related issues: #2637, #2649, #2651, #2655

## Root cause

Instagram revoked \`doc_id=7898261790222653\`. The endpoint still accepts the request but rejects the specific doc_id with a 401.

## Fix

Replace with \`doc_id=34579740524958711\` — the same endpoint (\`xdt_api__v1__feed__user_timeline_graphql_connection\`) already used by the fix in PR #2652 for \`from_username()\`. Nodes are returned in iphone_struct format, compatible with the existing \`Post.from_iphone_struct()\` wrapper.

This also simplifies the logged-in/anonymous branch: the new doc_id uses username-based variables (same as the timeline feed query), so the anonymous fallback path is no longer needed — Instagram no longer embeds post edges in the initial profile response anyway.

## Testing

Verified against \`@miamipadelcenter\` and \`@natgeo\` with authenticated cookie session:
- Profile fetched successfully
- \`get_posts()\` returns posts without 401
- \`download_post()\` saves \`.jpg\` and \`.txt\` files correctly