### PR TITLE
Fix persistent 429/401 errors via HTTP/2 adapter and updated doc_id

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -355,6 +355,7 @@ class InstaloaderContext:
         # pylint:disable=protected-access
         http.client._MAXHEADERS = 200
         session = requests.Session()
+        session.mount("https://", Http2Adapter())
         session.cookies.update({'sessionid': '', 'mid': '', 'ig_pr': '1',
                                 'ig_vw': '1920', 'ig_cb': '1', 'csrftoken': '',
                                 's_network': '', 'ds_user_id': ''})

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -13,10 +13,94 @@ from datetime import datetime, timedelta
 from functools import partial
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
+import httpx
 import requests
+import requests.cookies
 import requests.utils
 
 from .exceptions import *
+
+
+class _Http2HeaderMsg:
+    """Mimics the httplib.HTTPMessage interface that requests' MockResponse.info() expects."""
+    def __init__(self, httpx_headers):
+        self._h = httpx_headers
+
+    def get_all(self, name, default=None):
+        values = self._h.get_list(name.lower())
+        return values if values else default
+
+    def getheaders(self, name):
+        return self._h.get_list(name.lower())
+
+
+class _Http2OriginalResponse:
+    """Mimics urllib3.HTTPResponse so that requests' extract_cookies_to_jar guard
+    (checks for _original_response.msg) passes and can read Set-Cookie headers."""
+    def __init__(self, httpx_headers):
+        self.msg = _Http2HeaderMsg(httpx_headers)
+
+
+class _Http2RawResponse:
+    """Wraps an httpx response so that requests' Session.send() can extract
+    Set-Cookie headers from it into the session's cookie jar via
+    extract_cookies_to_jar(self.cookies, request, r.raw)."""
+    def __init__(self, httpx_headers):
+        self._original_response = _Http2OriginalResponse(httpx_headers)
+        self._msg = _Http2HeaderMsg(httpx_headers)
+
+    def info(self):
+        return self._msg
+
+
+class Http2Adapter(requests.adapters.BaseAdapter):
+    """Requests transport adapter that uses httpx for HTTP/2 support.
+
+    Instagram's API endpoints (notably api/v1/users/web_profile_info/) require
+    HTTP/2 on some network configurations. Without it, these endpoints return
+    429 Too Many Requests even on the first request from a fresh IP.
+
+    Also strips empty-value placeholder cookies before sending, which can
+    confuse Instagram's CSRF/session checks."""
+
+    def __init__(self):
+        self.client = httpx.Client(http2=True, follow_redirects=True)
+
+    def send(self, request, **kwargs):
+        # Strip empty-value cookies from the Cookie header before sending.
+        # instaloader pre-initialises cookies with '' (no domain) as placeholders;
+        # if those are sent alongside real domain-specific cookies, the duplicates
+        # confuse Instagram's CSRF / session checks.
+        headers = dict(request.headers)
+        cookie_header = headers.get('Cookie', headers.get('cookie', ''))
+        if cookie_header:
+            filtered = [p.strip() for p in cookie_header.split(';')
+                        if '=' not in p or p.split('=', 1)[1].strip() != '']
+            headers['Cookie'] = '; '.join(filtered) if filtered else ''
+            if not headers['Cookie']:
+                headers.pop('Cookie', None)
+
+        r = self.client.request(
+            request.method,
+            request.url,
+            headers=headers,
+            content=request.body,
+            timeout=kwargs.get('timeout'),
+        )
+        response = requests.Response()
+        response.status_code = r.status_code
+        response._content = r.content
+        response.headers = r.headers
+        response.url = str(r.url)
+        response.request = request
+        # Expose Set-Cookie headers via a mock raw response so that
+        # requests' extract_cookies_to_jar can update the session's cookie jar.
+        response.raw = _Http2RawResponse(r.headers)
+        requests.cookies.extract_cookies_to_jar(response.cookies, request, response.raw)
+        return response
+
+    def close(self):
+        self.client.close()
 
 
 def copy_session(session: requests.Session, request_timeout: Optional[float] = None) -> requests.Session:
@@ -27,6 +111,7 @@ def copy_session(session: requests.Session, request_timeout: Optional[float] = N
     # Override default timeout behavior.
     # Need to silence mypy bug for this. See: https://github.com/python/mypy/issues/2427
     new.request = partial(new.request, timeout=request_timeout)  # type: ignore
+    new.mount("https://", Http2Adapter())
     return new
 
 
@@ -228,6 +313,7 @@ class InstaloaderContext:
         # Override default timeout behavior.
         # Need to silence mypy bug for this. See: https://github.com/python/mypy/issues/2427
         session.request = partial(session.request, timeout=self.request_timeout)  # type: ignore
+        session.mount("https://", Http2Adapter())
         self._session = session
         self.username = username
 
@@ -246,7 +332,10 @@ class InstaloaderContext:
             return data["data"]["user"]["username"] if data["data"]["user"] is not None else None
         except (AbortDownloadException, ConnectionException) as err:
             self.error(f"Error when checking if logged in: {err}")
-            return None
+            # Return the stored username rather than None so that a transient
+            # connection failure (e.g. rate-limiting) does not trigger an
+            # interactive re-login prompt for a session that is still valid.
+            return self.username if self.username else None
 
     def login(self, user, passwd):
         """Not meant to be used directly, use :meth:`Instaloader.login`.

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1266,8 +1266,8 @@ class Profile:
                 "data": {
                     "count": 12,
                     "include_relationship_info": True,
-                    "latest_besties_reel_media": False,
-                    "latest_reel_media": False,
+                    "latest_besties_reel_media": True,
+                    "latest_reel_media": True,
                 },
                 "username": self.username,
             },

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1258,33 +1258,25 @@ class Profile:
 
         :rtype: NodeIterator[Post]"""
         self._obtain_metadata()
-        logged_in = self._context.is_logged_in
         return NodeIterator(
             context=self._context,
-            edge_extractor=(
-                (lambda d: d["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"])
-                if logged_in
-                else (lambda d: d["data"]["user"]["edge_owner_to_timeline_media"])
-            ),
-            node_wrapper=(
-                (lambda n: Post.from_iphone_struct(self._context, n))
-                if logged_in
-                else (lambda n: Post(self._context, n, self))
-            ),
+            edge_extractor=lambda d: d["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"],
+            node_wrapper=lambda n: Post.from_iphone_struct(self._context, n),
             query_variables={
                 "data": {
                     "count": 12,
                     "include_relationship_info": True,
-                    "latest_besties_reel_media": True,
-                    "latest_reel_media": True,
+                    "latest_besties_reel_media": False,
+                    "latest_reel_media": False,
                 },
-                **({"username": self.username} if logged_in else {"id": self.userid}),
+                "username": self.username,
             },
             query_referer="https://www.instagram.com/{0}/".format(self.username),
             is_first=Profile._make_is_newest_checker(),
-            doc_id="7898261790222653" if logged_in else "7950326061742207",
+            # doc_id 7898261790222653 was revoked by Instagram (returns 401).
+            # 34579740524958711 is the current replacement.
+            doc_id="34579740524958711",
             query_hash=None,
-            first_data=(None if logged_in else self._metadata("edge_owner_to_timeline_media")),
         )
 
     def get_saved_posts(self) -> NodeIterator[Post]:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_version():
 if sys.version_info < (3, 9):
     sys.exit('Instaloader requires Python >= 3.9.')
 
-requirements = ['requests>=2.25']
+requirements = ['requests>=2.25', 'httpx[http2]>=0.24']
 optional_requirements = {
     'browser_cookie3': ['browser_cookie3>=0.19.1'],
 }


### PR DESCRIPTION
## Summary

**Note**: PR #2677 is an alternative implementation of the same fix using https://github.com/jawah/niquests instead of a custom httpx adapter — cleaner if the maintainers are open to swapping the requests dependency.

Fixes the persistent 429 Too Many Requests errors reported in #2655 and the 401 errors from the revoked `doc_id` in `get_posts()`.

- **HTTP/2 adapter**: Adds an `Http2Adapter` class (backed by `httpx`) that upgrades all Instagram requests to HTTP/2. Instagram's `web_profile_info` and related endpoints return 429 on some hosts/networks (NAS devices, containers, certain ISPs) under HTTP/1.1 but succeed reliably with HTTP/2. Confirmed working where PR #2652 alone was insufficient.
- **Empty-cookie stripping**: The adapter filters out empty-value placeholder cookies before sending — these confuse Instagram's CSRF/session checks and can cause spurious 401s.
- **Updated `doc_id` in `get_posts()`**: `7898261790222653` was revoked by Instagram and returns 401 for all users. Replaced with `34579740524958711`. Removed the now-broken anonymous fallback path since this endpoint requires a logged-in session.
- **Resilient `test_login()`**: Returns the stored username on connection error instead of `None`, so a transient rate-limit failure doesn't trigger an interactive re-login prompt for a valid session.
- **New dependency**: `httpx[http2]>=0.24` added to `install_requires`.

## Test plan

- [ ] `pip install git+https://github.com/irishpadres/instaloader.git` and run `instaloader` against a profile that previously returned 429 immediately
- [ ] Verify `get_posts()` works for a logged-in session (no 401 on first page fetch)
- [ ] Verify loading a saved session file still works and HTTP/2 adapter is active
- [ ] Verify that a connection error during `test_login()` does not force re-login when a valid session is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)