### PR TITLE
Fix profile metadata GraphQL query flags

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -990,8 +990,10 @@ class Profile:
                     "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
                     "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
                     "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
+                    "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
+                    "enable_integrity_filters": True,
                 }
-                data = self._context.doc_id_graphql_query('25980296051578533', variables)
+                data = self._context.doc_id_graphql_query('27937681195819736', variables)
                 if data is None:
                     raise QueryReturnedNotFoundException('GraphQL query returned None')
                 user_data = data.get('data', {}).get('user')


### PR DESCRIPTION
Fixes the profile metadata request after Instagram-side changes.

Changes:
- switch to GraphQL doc id 27937681195819736
- add __relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider = False
- add enable_integrity_filters = True

Credit: this patch is based on the workaround shared by [@VupVup in issue #2695](https://github.com/instaloader/instaloader/issues/2695#issuecomment-4495553287).