### PR TITLE
Fix profile resolution after Instagram retired its GraphQL profile queries

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -191,7 +191,8 @@ class InstaloaderContext:
                   'Referer': 'https://www.instagram.com/',
                   'User-Agent': self.user_agent,
                   'X-Instagram-AJAX': '1',
-                  'X-Requested-With': 'XMLHttpRequest'}
+                  'X-Requested-With': 'XMLHttpRequest',
+                  'x-ig-app-id': '936619743392459'}
         if empty_session_only:
             del header['Host']
             del header['Origin']

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -912,11 +912,20 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
-        data = context.doc_id_graphql_query("26347858941511777", {"hasQuery": True, "query": username})["data"]
-        if data:
-            for user in data["xdt_api__v1__fbsearch__non_profiled_serp"]["users"]:
-                if user["username"].lower() == username.lower():
-                    return cls(context, user)
+        # Resolve the profile through the web_profile_info endpoint, which works both
+        # anonymously and when logged in and returns the complete profile node
+        # (including the first page of posts). The GraphQL fbsearch query previously
+        # used here started responding with HTTP 400.
+        try:
+            data = context.get_json(
+                "api/v1/users/web_profile_info/", params={"username": username.lower()}
+            ).get("data")
+        except QueryReturnedNotFoundException:
+            data = None
+        if data and data.get("user"):
+            profile = cls(context, data["user"])
+            profile._has_full_metadata = True
+            return profile
 
         raise ProfileNotExistsException("Profile {} does not exist.".format(username))
 
@@ -931,15 +940,16 @@ class Profile:
         """
         if profile_id in context.profile_id_cache:
             return context.profile_id_cache[profile_id]
-        data = context.graphql_query('7c16654f22c819fb63d1183034a5162f',
-                                     {'user_id': str(profile_id),
-                                      'include_chaining': False,
-                                      'include_reel': True,
-                                      'include_suggested_users': False,
-                                      'include_logged_out_extras': False,
-                                      'include_highlight_reels': False})['data']['user']
-        if data:
-            profile = cls(context, data['reel']['owner'])
+        # Resolve the current username from the user id, then load the full profile.
+        # The GraphQL user query previously used here started responding with HTTP 400.
+        try:
+            user = context.get_json(
+                "api/v1/users/{0}/info/".format(profile_id), params={}
+            ).get('user')
+        except QueryReturnedNotFoundException:
+            user = None
+        if user and user.get('username'):
+            profile = cls.from_username(context, user['username'])
         else:
             raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
                                             str(profile_id) + ").")
@@ -985,6 +995,24 @@ class Profile:
     def _obtain_metadata(self):
         try:
             if not self._has_full_metadata:
+                if not self._context.is_logged_in:
+                    # Anonymous access: the web_profile_info endpoint returns the full
+                    # node in the legacy format and still works, unlike the GraphQL
+                    # profile query.
+                    try:
+                        data = self._context.get_json(
+                            "api/v1/users/web_profile_info/",
+                            params={"username": self.username},
+                        ).get('data')
+                    except QueryReturnedNotFoundException as err:
+                        raise ProfileNotExistsException(
+                            'Profile {} does not exist.'.format(self.username)) from err
+                    user_data = data.get('user') if data else None
+                    if user_data is None:
+                        raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
+                    self._node = user_data
+                    self._has_full_metadata = True
+                    return
                 user_id = self._node.get('id') or self._node.get('pk')
                 variables = {
                     "id": str(user_id),


### PR DESCRIPTION
## Fix profile resolution after Instagram retired its GraphQL profile queries

Fixes #2695

### Problem

Instagram stopped serving the GraphQL endpoints Instaloader relies on for profile resolution, so every profile download now fails before any media is fetched. Three separate queries are affected:

| Method | Old query | Symptom |
| --- | --- | --- |
| `Profile.from_username` | `fbsearch/non_profiled_serp` (`doc_id 26347858941511777`) | `400 Bad Request` on `api/graphql` |
| `Profile.from_id` | `graphql_query 7c16654f22c819fb63d1183034a5162f` | `400 Bad Request` on `graphql/query` |
| `Profile._obtain_metadata` | `doc_id 25980296051578533` | `400 Bad Request` on `graphql/query` |

The existing community workaround ([#2696](https://github.com/instaloader/instaloader/pull/2696)) only updates the `_obtain_metadata` `doc_id`. That fixes the *logged-in* metadata fetch but leaves `from_username` and `from_id` broken, and does nothing for anonymous use – which is why several people in #2695 reported it "works logged in, but profile-not-found when logged out."

### Fix

Resolve profiles through Instagram's web API endpoints, which still work **both anonymously and when logged in** and return the profile node in the legacy format the rest of `Profile` already expects:

- **New `InstaloaderContext.web_profile_info(username)`** → `api/v1/users/web_profile_info/`. Returns the complete profile node, including the first page of timeline posts.
- **New `InstaloaderContext.web_user_info(user_id)`** → `api/v1/users/{id}/info/`. Resolves the current username for a given user id.

Both require the `www.instagram.com` web app id (`x-ig-app-id: 936619743392459`); the default app id is rejected with HTTP 400.

Wiring:

- `from_username` now calls `web_profile_info` and marks the node as fully populated, so no redundant follow-up query is made.
- `from_id` resolves the id → current username via `web_user_info`, then delegates to `from_username` (so renamed accounts are still handled).
- `_obtain_metadata` uses `web_profile_info` when anonymous. The logged-in branch keeps the `doc_id` query but adopts the values from #2696 (`doc_id 27937681195819736` plus `__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider=False` and `enable_integrity_filters=True`), so it still serves as a fallback for partially constructed profiles. Credit to @VupVup / #2696 for those values.

### Testing

Verified against a real account both ways:

- **Anonymous:** `from_username`, full metadata property access (no extra request), `get_posts` pagination across the first page boundary, `from_id`, and `ProfileNotExistsException` for a nonexistent username and id.
- **Logged in** (session imported from a browser): `from_username`, the logged-in `_obtain_metadata` `doc_id` branch, `from_id`, `get_posts` (iphone/xdt path), and a CLI profile download that fetched media successfully.