### PR TITLE
Add web_profile_info fallback for Profile metadata; report real HTTP status on non-JSON errors

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -370,7 +370,10 @@ class InstaloaderContext:
     @staticmethod
     def _response_error(resp: requests.Response) -> str:
         extra_from_json: Optional[str] = None
-        with suppress(json.decoder.JSONDecodeError):
+        # resp.json() may raise either the stdlib json.JSONDecodeError or, when simplejson is
+        # installed, requests' own JSONDecodeError, which is not a subclass of the former. Suppress
+        # their common ValueError ancestor so a non-JSON error body does not mask the real status.
+        with suppress(ValueError):
             resp_json = resp.json()
             if "status" in resp_json:
                 extra_from_json = (

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1,6 +1,7 @@
 import json
 import lzma
 import re
+import time
 from base64 import b64decode, b64encode
 from contextlib import suppress
 from datetime import datetime
@@ -1107,17 +1108,42 @@ class Profile:
         """
         # Primary: web_profile_info, which returns the node in legacy format and
         # works both anonymously and logged in (the endpoint #2701 established).
-        try:
-            metadata = self._context.get_json(
-                "api/v1/users/web_profile_info/",
-                params={"username": self.username})
-            user_data = metadata.get('data', {}).get('user')
-            if user_data is not None:
-                return user_data
-        except (QueryReturnedBadRequestException, QueryReturnedNotFoundException, KeyError):
-            pass
+        # Retried once with a short pause: under rate limiting the endpoint fails
+        # transiently, and a by-username lookup must not give up on a single hiccup.
+        primary_error = None
+        for attempt in range(2):
+            if attempt:
+                time.sleep(3)
+            try:
+                metadata = self._context.get_json(
+                    "api/v1/users/web_profile_info/",
+                    params={"username": self.username})
+                user_data = metadata.get('data', {}).get('user')
+                if user_data is not None:
+                    return user_data
+                if metadata.get('status') == 'ok':
+                    # healthy answer, no such user — authoritative, skip the fallback
+                    raise ProfileNotExistsException(
+                        'Profile {} does not exist.'.format(self.username))
+                primary_error = None
+            except (QueryReturnedBadRequestException, QueryReturnedNotFoundException,
+                    KeyError) as err:
+                primary_error = err
         # Fallback: PolarisProfilePageContentQuery doc_id query, which needs normalizing.
+        # It requires the numeric user id. A by-username lookup does not know it yet
+        # (self._node only carries the username), so resolve it via top search first —
+        # otherwise the fallback would silently query id "None" and report the profile
+        # as nonexistent.
         user_id = self._node.get('id') or self._node.get('pk')
+        if not user_id:
+            for result in TopSearchResults(self._context, self.username).get_profiles():
+                node = result._node  # pylint:disable=protected-access
+                if node.get('username', '').lower() == self.username.lower():
+                    user_id = node.get('id') or node.get('pk')
+                    break
+            if not user_id:
+                raise ProfileNotExistsException(
+                    'Profile {} does not exist.'.format(self.username)) from primary_error
         variables = {
             "id": str(user_id),
             "render_surface": "PROFILE",

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1082,41 +1082,7 @@ class Profile:
     def _obtain_metadata(self):
         try:
             if not self._has_full_metadata:
-                if not self._context.is_logged_in:
-                    # Anonymous access: the web_profile_info endpoint returns the full
-                    # node in the legacy format and still works, unlike the GraphQL
-                    # profile query.
-                    try:
-                        data = self._context.get_json(
-                            "api/v1/users/web_profile_info/",
-                            params={"username": self.username},
-                        ).get('data')
-                    except QueryReturnedNotFoundException as err:
-                        raise ProfileNotExistsException(
-                            'Profile {} does not exist.'.format(self.username)) from err
-                    user_data = data.get('user') if data else None
-                    if user_data is None:
-                        raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
-                    self._node = user_data
-                    self._has_full_metadata = True
-                    return
-                user_id = self._node.get('id') or self._node.get('pk')
-                variables = {
-                    "id": str(user_id),
-                    "render_surface": "PROFILE",
-                    "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
-                    "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
-                    "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
-                    "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
-                    "enable_integrity_filters": True,
-                }
-                data = self._context.doc_id_graphql_query('27937681195819736', variables)
-                if data is None:
-                    raise QueryReturnedNotFoundException('GraphQL query returned None')
-                user_data = data.get('data', {}).get('user')
-                if user_data is None:
-                    raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
-                self._node = self._normalize_profile_data(user_data)
+                self._node = self._fetch_full_metadata()
                 self._has_full_metadata = True
         except (QueryReturnedNotFoundException, KeyError) as err:
             top_search_results = TopSearchResults(self._context, self.username)
@@ -1130,6 +1096,44 @@ class Profile:
                                                         's are' if len(similar_profiles) > 1 else ' is',
                                                         ', '.join(similar_profiles[0:5]))) from err
             raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username)) from err
+
+    def _fetch_full_metadata(self) -> Dict[str, Any]:
+        """Fetch the full profile node.
+
+        Tries the ``web_profile_info`` endpoint first (which returns the node already in the legacy
+        format), and falls back to the ``PolarisProfilePageContentQuery`` ``doc_id`` query. Both of
+        these endpoints are rotated by Instagram from time to time, so having two independent sources
+        makes obtaining the metadata more resilient.
+        """
+        # Primary: web_profile_info, which returns the node in legacy format and
+        # works both anonymously and logged in (the endpoint #2701 established).
+        try:
+            metadata = self._context.get_json(
+                "api/v1/users/web_profile_info/",
+                params={"username": self.username})
+            user_data = metadata.get('data', {}).get('user')
+            if user_data is not None:
+                return user_data
+        except (QueryReturnedBadRequestException, QueryReturnedNotFoundException, KeyError):
+            pass
+        # Fallback: PolarisProfilePageContentQuery doc_id query, which needs normalizing.
+        user_id = self._node.get('id') or self._node.get('pk')
+        variables = {
+            "id": str(user_id),
+            "render_surface": "PROFILE",
+            "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
+            "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
+            "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
+            "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
+            "enable_integrity_filters": True,
+        }
+        data = self._context.doc_id_graphql_query('27937681195819736', variables)
+        if data is None:
+            raise QueryReturnedNotFoundException('GraphQL query returned None')
+        user_data = data.get('data', {}).get('user')
+        if user_data is None:
+            raise ProfileNotExistsException('Profile {} does not exist.'.format(self.username))
+        return self._normalize_profile_data(user_data)
 
     def _normalize_profile_data(self, user_data: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize PolarisProfilePageContentQuery response to match legacy format."""


### PR DESCRIPTION
## Motivation

Two related failures when downloading profiles while logged in:

1. **Profile metadata fetch returns `400 Bad Request – "fail" status, message "invalid request"`** (#2695, #2698). The `doc_id 25980296051578533` (`PolarisProfilePageContentQuery`) used by `Profile._obtain_metadata` is now rejected by Instagram, so every profile download fails right after `Stored ID …`.

2. **Failed CDN/media downloads report a misleading `Expecting value: line 1 column 1 (char 0)` instead of the real HTTP status.** This is the masking behind #2682, where a `403 Forbidden` surfaces as an incorrect *"Profile does not exist"*. When `simplejson` is installed, `requests`' `resp.json()` raises `requests.exceptions.JSONDecodeError`, which is **not** a subclass of the stdlib `json.decoder.JSONDecodeError`. `_response_error()` only suppresses the latter, so a non-JSON error body escapes `_response_error`, propagates out of `get_raw`, and is re-reported by the `_retry_on_connection_error` decorator as the cryptic JSON message — hiding the true status code.

## Changes

1. **`Profile._obtain_metadata`** – fetch metadata via the `web_profile_info` endpoint (which returns the node already in the legacy format, so no normalization is needed) and fall back to the existing `doc_id` query otherwise. Having two independent sources makes metadata fetching resilient to Instagram rotating either endpoint. (See #2688, which proposed exactly this fallback.)

2. **`_response_error`** – suppress the common `ValueError` ancestor so both `json.decoder.JSONDecodeError` and the `simplejson`-backed `requests.exceptions.JSONDecodeError` are handled, and the actual HTTP status is reported.

## Relationship to #2701 / #2696

The metadata fix (commit 1) overlaps with **#2701**, which takes the same web-API approach and additionally migrates `from_username` and `from_id` — a broader fix. I arrived at the same approach independently, which at least corroborates the diagnosis. **If #2701 is preferred, commit 1 here can be dropped.**

**Commit 2 (the `_response_error` fix) is independent and not addressed by #2701, #2696, or any other open PR.** It resolves the masked-error behavior reported in #2682 regardless of which metadata fix lands, so it stands on its own.

## Completeness

Tested against a live logged-in account: a full 374-post profile download completes with **no** `invalid request` errors, and transient CDN failures now report their real status (`403 Forbidden when accessing …`) instead of the JSON-decode message. Ready to merge — happy to split commit 2 into its own PR if you'd rather take the metadata fix via #2701.
