### PR TITLE
Guard against null `data` in Post metadata response

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -319,9 +319,11 @@ class Post:
 
     def _obtain_metadata(self):
         if not self._full_metadata_dict:
-            pic_json = self._context.doc_id_graphql_query(
+            response = self._context.doc_id_graphql_query(
                 "8845758582119845", {"shortcode": self.shortcode}
-            )["data"]["xdt_shortcode_media"]
+            )
+            data = (response or {}).get("data")
+            pic_json = data.get("xdt_shortcode_media") if data else None
             if pic_json is None:
                 raise BadResponseException("Fetching Post metadata failed.")
             try:


### PR DESCRIPTION
When Instagram returns `{"data": null}` for a shortcode metadata query (e.g. under rate limiting, or for an unavailable post), `Post._obtain_metadata` did `response["data"]["xdt_shortcode_media"]` and raised a raw `TypeError: 'NoneType' object is not subscriptable` — *before* the existing `if pic_json is None` check could run.

This guards the intermediate `data` so the existing `BadResponseException("Fetching Post metadata failed.")` is raised instead, which the download loop already handles gracefully (skip the post, continue) rather than crashing with a traceback.

Hits intermittently during large/throttled runs.

`pylint` 10.00/10, `mypy` clean.