### PR TITLE
Fix Post metadata fetching broken by Instagram deprecating doc_id

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -540,6 +540,13 @@ class InstaloaderContext:
         :param referer: HTTP Referer, or None.
         :return: The server's response dictionary.
         """
+        csrf = next((c.value for c in self._session.cookies
+                     if c.name == 'csrftoken' and c.value), None)
+        if not csrf:
+            self._session.get('https://www.instagram.com/', timeout=self.request_timeout)
+            csrf = next((c.value for c in self._session.cookies
+                         if c.name == 'csrftoken' and c.value), '')
+
         with copy_session(self._session, self.request_timeout) as tmpsession:
             tmpsession.headers.update(self._default_http_header(empty_session_only=True))
             del tmpsession.headers['Connection']
@@ -547,6 +554,7 @@ class InstaloaderContext:
             tmpsession.headers['authority'] = 'www.instagram.com'
             tmpsession.headers['scheme'] = 'https'
             tmpsession.headers['accept'] = '*/*'
+            tmpsession.headers['x-csrftoken'] = csrf
             if referer is not None:
                 tmpsession.headers['referer'] = urllib.parse.quote(referer)
 

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -274,9 +274,81 @@ class Post:
                 media = (edge.get("node") or {}).get("media") or {}
                 if media.get("code") == shortcode:
                     return media.get("play_count")
-        except Exception:
+        except (ConnectionException, BadResponseException):
             pass
         return None
+
+    @staticmethod
+    def _normalize_post_data(media: Dict[str, Any], context: 'InstaloaderContext') -> Dict[str, Any]:
+        """Normalize a Polaris media item to a legacy-compatible node, preserving the source structure."""
+        media_types = {1: "GraphImage", 2: "GraphVideo", 8: "GraphSidecar"}
+        media_type = media.get("media_type")
+        typename = media_types.get(media_type)
+        if not typename:
+            raise BadResponseException(f"Unknown media_type in metadata: {media_type}.")
+        pic_json: Dict[str, Any] = media.copy()
+        pic_json["shortcode"] = media["code"]
+        pic_json["id"] = media["pk"]
+        pic_json["__typename"] = typename
+        pic_json["is_video"] = media_type == 2
+        pic_json["taken_at_timestamp"] = media["taken_at"]
+        pic_json["owner"] = {
+            "id": media["user"]["pk"],
+            "username": media["user"].get("username", ""),
+            "full_name": media["user"].get("full_name", ""),
+        }
+        candidates = (media.get("image_versions2") or {}).get("candidates") or []
+        pic_json["display_url"] = candidates[0]["url"] if candidates else None
+        video_versions = media.get("video_versions") or []
+        pic_json["video_url"] = video_versions[0]["url"] if video_versions else None
+        pic_json["video_duration"] = media.get("video_duration")
+        pic_json["video_view_count"] = media.get("view_count")
+        pic_json["video_play_count"] = media.get("play_count")
+        if media_type == 2 and pic_json["video_view_count"] is None:
+            pic_json["video_play_count"] = Post._fetch_play_count_from_clips(
+                context, media["user"]["pk"], media["code"]
+            )
+        caption = media.get("caption")
+        caption_text = caption.get("text") if isinstance(caption, dict) else None
+        pic_json["edge_media_to_caption"] = (
+            {"edges": [{"node": {"text": caption_text}}]} if caption_text is not None
+            else {"edges": []}
+        )
+        pic_json["edge_media_preview_like"] = {"count": media.get("like_count") or 0}
+        pic_json["edge_media_to_parent_comment"] = {
+            "count": media.get("comment_count") or 0,
+            "edges": [],
+        }
+        if media.get("has_liked") is not None:
+            pic_json["viewer_has_liked"] = media["has_liked"]
+        carousel = media.get("carousel_media") or []
+        if carousel:
+            carousel_nodes = []
+            for item in carousel:
+                item_type = item.get("media_type", 1)
+                node: Dict[str, Any] = {
+                    "shortcode": item.get("code", ""),
+                    "__typename": media_types.get(item_type, "GraphImage"),
+                    "is_video": item_type == 2,
+                }
+                item_candidates = (item.get("image_versions2") or {}).get("candidates") or []
+                node["display_url"] = item_candidates[0]["url"] if item_candidates else ""
+                item_videos = item.get("video_versions") or []
+                node["video_url"] = item_videos[0]["url"] if item_videos else None
+                if item.get("accessibility_caption") is not None:
+                    node["accessibility_caption"] = item["accessibility_caption"]
+                carousel_nodes.append({"node": node})
+            pic_json["edge_sidecar_to_children"] = {"edges": carousel_nodes}
+        tagged = (media.get("usertags") or {}).get("in") or []
+        if tagged:
+            pic_json["edge_media_to_tagged_user"] = {
+                "edges": [
+                    {"node": {"user": {"username": t["user"]["username"].lower()}}}
+                    for t in tagged
+                    if (t.get("user") or {}).get("username")
+                ]
+            }
+        return pic_json
 
     @staticmethod
     def shortcode_to_mediaid(code: str) -> int:
@@ -339,7 +411,6 @@ class Post:
 
     def _obtain_metadata(self):
         if not self._full_metadata_dict:
-            media_types = {1: "GraphImage", 2: "GraphVideo", 8: "GraphSidecar"}
             resp = self._context.doc_id_graphql_query(
                 "27128499623469141",
                 {
@@ -351,86 +422,7 @@ class Post:
             items = web_info.get("items")
             if not items:
                 raise BadResponseException("Fetching Post metadata failed.")
-            media = items[0]
-            media_type = media.get("media_type")
-            typename = media_types.get(media_type)
-            if not typename:
-                raise BadResponseException(f"Unknown media_type in metadata: {media_type}.")
-            pic_json: Dict[str, Any] = {
-                "shortcode": media["code"],
-                "id": media["pk"],
-                "__typename": typename,
-                "is_video": media_type == 2,
-                "taken_at_timestamp": media["taken_at"],
-                "owner": {
-                    "id": media["user"]["pk"],
-                    "username": media["user"].get("username", ""),
-                    "full_name": media["user"].get("full_name", ""),
-                },
-            }
-            candidates = (media.get("image_versions2") or {}).get("candidates") or []
-            if candidates:
-                pic_json["display_url"] = candidates[0]["url"]
-            video_versions = media.get("video_versions") or []
-            if video_versions:
-                pic_json["video_url"] = video_versions[0]["url"]
-            if media.get("video_duration") is not None:
-                pic_json["video_duration"] = media["video_duration"]
-            if media.get("view_count") is not None:
-                pic_json["video_view_count"] = media["view_count"]
-            if media.get("play_count") is not None:
-                pic_json["video_play_count"] = media["play_count"]
-            if media_type == 2 and pic_json.get("video_view_count") is None:
-                play_count = Post._fetch_play_count_from_clips(
-                    self._context, media["user"]["pk"], media["code"]
-                )
-                if play_count is not None:
-                    pic_json["video_play_count"] = play_count
-            caption = media.get("caption")
-            caption_text = caption.get("text") if isinstance(caption, dict) else None
-            pic_json["edge_media_to_caption"] = (
-                {"edges": [{"node": {"text": caption_text}}]} if caption_text is not None
-                else {"edges": []}
-            )
-            pic_json["edge_media_preview_like"] = {"count": media.get("like_count") or 0}
-            pic_json["edge_media_to_parent_comment"] = {
-                "count": media.get("comment_count") or 0,
-                "edges": [],
-            }
-            if media.get("has_liked") is not None:
-                pic_json["viewer_has_liked"] = media["has_liked"]
-            if media.get("accessibility_caption") is not None:
-                pic_json["accessibility_caption"] = media["accessibility_caption"]
-            if media.get("location"):
-                pic_json["location"] = media["location"]
-            carousel = media.get("carousel_media") or []
-            if carousel:
-                carousel_nodes = []
-                for item in carousel:
-                    item_type = item.get("media_type", 1)
-                    node: Dict[str, Any] = {
-                        "shortcode": item.get("code", ""),
-                        "__typename": media_types.get(item_type, "GraphImage"),
-                        "is_video": item_type == 2,
-                    }
-                    item_candidates = (item.get("image_versions2") or {}).get("candidates") or []
-                    node["display_url"] = item_candidates[0]["url"] if item_candidates else ""
-                    item_videos = item.get("video_versions") or []
-                    node["video_url"] = item_videos[0]["url"] if item_videos else None
-                    if item.get("accessibility_caption") is not None:
-                        node["accessibility_caption"] = item["accessibility_caption"]
-                    carousel_nodes.append({"node": node})
-                pic_json["edge_sidecar_to_children"] = {"edges": carousel_nodes}
-            tagged = (media.get("usertags") or {}).get("in") or []
-            if tagged:
-                pic_json["edge_media_to_tagged_user"] = {
-                    "edges": [
-                        {"node": {"user": {"username": t["user"]["username"].lower()}}}
-                        for t in tagged
-                        if (t.get("user") or {}).get("username")
-                    ]
-                }
-            self._full_metadata_dict = pic_json
+            self._full_metadata_dict = Post._normalize_post_data(items[0], self._context)
             if self.shortcode != self._full_metadata_dict['shortcode']:
                 self._node.update(self._full_metadata_dict)
                 raise PostChangedException
@@ -694,10 +686,7 @@ class Post:
 
         .. versionadded:: 4.2.6"""
         if self.is_video:
-            try:
-                return self._field('video_view_count')
-            except KeyError:
-                return None
+            return self._field('video_view_count')
         return None
 
     @property
@@ -706,10 +695,7 @@ class Post:
 
         .. versionadded:: 4.14.3"""
         if self.is_video:
-            try:
-                return self._field('video_play_count')
-            except KeyError:
-                return None
+            return self._field('video_play_count')
         return None
 
     @property
@@ -1030,23 +1016,18 @@ class Profile:
         """
         if profile_id in context.profile_id_cache:
             return context.profile_id_cache[profile_id]
-        resp = context.doc_id_graphql_query(
-            '27937681195819736',
-            {
-                "enable_integrity_filters": True,
-                "id": str(profile_id),
-                "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
-                "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
-                "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
-                "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
-            },
-        )
-        user_data = (resp.get('data') or {}).get('user')
-        if not user_data:
+        data = context.graphql_query('7c16654f22c819fb63d1183034a5162f',
+                                     {'user_id': str(profile_id),
+                                      'include_chaining': False,
+                                      'include_reel': True,
+                                      'include_suggested_users': False,
+                                      'include_logged_out_extras': False,
+                                      'include_highlight_reels': False})['data']['user']
+        if data:
+            profile = cls(context, data['reel']['owner'])
+        else:
             raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
                                             str(profile_id) + ").")
-        node = {'id': user_data.get('pk', str(profile_id)), 'username': user_data.get('username', '')}
-        profile = cls(context, node)
         context.profile_id_cache[profile_id] = profile
         return profile
 
@@ -1097,8 +1078,6 @@ class Profile:
                     "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
                     "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
                     "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
-                    "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
-                    "enable_integrity_filters": True,
                 }
                 data = self._context.doc_id_graphql_query('27937681195819736', variables)
                 if data is None:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1030,18 +1030,23 @@ class Profile:
         """
         if profile_id in context.profile_id_cache:
             return context.profile_id_cache[profile_id]
-        data = context.graphql_query('7c16654f22c819fb63d1183034a5162f',
-                                     {'user_id': str(profile_id),
-                                      'include_chaining': False,
-                                      'include_reel': True,
-                                      'include_suggested_users': False,
-                                      'include_logged_out_extras': False,
-                                      'include_highlight_reels': False})['data']['user']
-        if data:
-            profile = cls(context, data['reel']['owner'])
-        else:
+        resp = context.doc_id_graphql_query(
+            '26672929172408668',
+            {
+                "enable_integrity_filters": True,
+                "id": str(profile_id),
+                "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
+                "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
+                "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
+                "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
+            },
+        )
+        user_data = (resp.get('data') or {}).get('user')
+        if not user_data:
             raise ProfileNotExistsException("No profile found, the user may have blocked you (ID: " +
                                             str(profile_id) + ").")
+        node = {'id': user_data.get('pk', str(profile_id)), 'username': user_data.get('username', '')}
+        profile = cls(context, node)
         context.profile_id_cache[profile_id] = profile
         return profile
 
@@ -1086,13 +1091,14 @@ class Profile:
             if not self._has_full_metadata:
                 user_id = self._node.get('id') or self._node.get('pk')
                 variables = {
+                    "enable_integrity_filters": True,
                     "id": str(user_id),
-                    "render_surface": "PROFILE",
                     "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
                     "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
+                    "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
                     "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
                 }
-                data = self._context.doc_id_graphql_query('25980296051578533', variables)
+                data = self._context.doc_id_graphql_query('26672929172408668', variables)
                 if data is None:
                     raise QueryReturnedNotFoundException('GraphQL query returned None')
                 user_data = data.get('data', {}).get('user')

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -388,11 +388,9 @@ class Post:
                         "is_video": item_type == 2,
                     }
                     item_candidates = (item.get("image_versions2") or {}).get("candidates") or []
-                    if item_candidates:
-                        node["display_url"] = item_candidates[0]["url"]
+                    node["display_url"] = item_candidates[0]["url"] if item_candidates else ""
                     item_videos = item.get("video_versions") or []
-                    if item_videos:
-                        node["video_url"] = item_videos[0]["url"]
+                    node["video_url"] = item_videos[0]["url"] if item_videos else None
                     if item.get("accessibility_caption") is not None:
                         node["accessibility_caption"] = item["accessibility_caption"]
                     carousel_nodes.append({"node": node})

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -321,7 +321,11 @@ class Post:
         if not self._full_metadata_dict:
             media_types = {1: "GraphImage", 2: "GraphVideo", 8: "GraphSidecar"}
             resp = self._context.doc_id_graphql_query(
-                "27128499623469141", {"shortcode": self.shortcode}
+                "27128499623469141",
+                {
+                    "shortcode": self.shortcode,
+                    "__relay_internal__pv__PolarisAIGMMediaWebLabelEnabledrelayprovider": False,
+                },
             )
             web_info = (resp.get("data") or {}).get("xdt_api__v1__media__shortcode__web_info") or {}
             items = web_info.get("items")

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -1072,12 +1072,13 @@ class Profile:
             if not self._has_full_metadata:
                 user_id = self._node.get('id') or self._node.get('pk')
                 variables = {
-                    "enable_integrity_filters": True,
                     "id": str(user_id),
+                    "render_surface": "PROFILE",
                     "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
                     "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
-                    "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
                     "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
+                    "__relay_internal__pv__PolarisWebSchoolsEnabledrelayprovider": False,
+                    "enable_integrity_filters": True,
                 }
                 data = self._context.doc_id_graphql_query('27937681195819736', variables)
                 if data is None:

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -319,22 +319,89 @@ class Post:
 
     def _obtain_metadata(self):
         if not self._full_metadata_dict:
-            pic_json = self._context.doc_id_graphql_query(
-                "8845758582119845", {"shortcode": self.shortcode}
-            )["data"]["xdt_shortcode_media"]
-            if pic_json is None:
+            media_types = {1: "GraphImage", 2: "GraphVideo", 8: "GraphSidecar"}
+            resp = self._context.doc_id_graphql_query(
+                "27128499623469141", {"shortcode": self.shortcode}
+            )
+            web_info = (resp.get("data") or {}).get("xdt_api__v1__media__shortcode__web_info") or {}
+            items = web_info.get("items")
+            if not items:
                 raise BadResponseException("Fetching Post metadata failed.")
-            try:
-                xdt_types = {
-                    "XDTGraphImage": "GraphImage",
-                    "XDTGraphVideo": "GraphVideo",
-                    "XDTGraphSidecar": "GraphSidecar",
+            media = items[0]
+            media_type = media.get("media_type")
+            typename = media_types.get(media_type)
+            if not typename:
+                raise BadResponseException(f"Unknown media_type in metadata: {media_type}.")
+            pic_json: Dict[str, Any] = {
+                "shortcode": media["code"],
+                "id": media["pk"],
+                "__typename": typename,
+                "is_video": media_type == 2,
+                "taken_at_timestamp": media["taken_at"],
+                "owner": {
+                    "id": media["user"]["pk"],
+                    "username": media["user"].get("username", ""),
+                    "full_name": media["user"].get("full_name", ""),
+                },
+            }
+            candidates = (media.get("image_versions2") or {}).get("candidates") or []
+            if candidates:
+                pic_json["display_url"] = candidates[0]["url"]
+            video_versions = media.get("video_versions") or []
+            if video_versions:
+                pic_json["video_url"] = video_versions[0]["url"]
+            if media.get("video_duration") is not None:
+                pic_json["video_duration"] = media["video_duration"]
+            if media.get("view_count") is not None:
+                pic_json["video_view_count"] = media["view_count"]
+            if media.get("play_count") is not None:
+                pic_json["video_play_count"] = media["play_count"]
+            caption = media.get("caption")
+            caption_text = caption.get("text") if isinstance(caption, dict) else None
+            pic_json["edge_media_to_caption"] = (
+                {"edges": [{"node": {"text": caption_text}}]} if caption_text is not None
+                else {"edges": []}
+            )
+            pic_json["edge_media_preview_like"] = {"count": media.get("like_count") or 0}
+            pic_json["edge_media_to_parent_comment"] = {
+                "count": media.get("comment_count") or 0,
+                "edges": [],
+            }
+            if media.get("has_liked") is not None:
+                pic_json["viewer_has_liked"] = media["has_liked"]
+            if media.get("accessibility_caption") is not None:
+                pic_json["accessibility_caption"] = media["accessibility_caption"]
+            if media.get("location"):
+                pic_json["location"] = media["location"]
+            carousel = media.get("carousel_media") or []
+            if carousel:
+                carousel_nodes = []
+                for item in carousel:
+                    item_type = item.get("media_type", 1)
+                    node: Dict[str, Any] = {
+                        "shortcode": item.get("code", ""),
+                        "__typename": media_types.get(item_type, "GraphImage"),
+                        "is_video": item_type == 2,
+                    }
+                    item_candidates = (item.get("image_versions2") or {}).get("candidates") or []
+                    if item_candidates:
+                        node["display_url"] = item_candidates[0]["url"]
+                    item_videos = item.get("video_versions") or []
+                    if item_videos:
+                        node["video_url"] = item_videos[0]["url"]
+                    if item.get("accessibility_caption") is not None:
+                        node["accessibility_caption"] = item["accessibility_caption"]
+                    carousel_nodes.append({"node": node})
+                pic_json["edge_sidecar_to_children"] = {"edges": carousel_nodes}
+            tagged = (media.get("usertags") or {}).get("in") or []
+            if tagged:
+                pic_json["edge_media_to_tagged_user"] = {
+                    "edges": [
+                        {"node": {"user": {"username": t["user"]["username"].lower()}}}
+                        for t in tagged
+                        if (t.get("user") or {}).get("username")
+                    ]
                 }
-                pic_json["__typename"] = xdt_types[pic_json["__typename"]]
-            except KeyError as exc:
-                raise BadResponseException(
-                    f"Unknown __typename in metadata: {pic_json['__typename']}."
-                ) from exc
             self._full_metadata_dict = pic_json
             if self.shortcode != self._full_metadata_dict['shortcode']:
                 self._node.update(self._full_metadata_dict)

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -259,6 +259,26 @@ class Post:
         return fake_node
 
     @staticmethod
+    def _fetch_play_count_from_clips(context: 'InstaloaderContext', user_id: str,
+                                     shortcode: str) -> Optional[int]:
+        """Fetch play_count for a reel via the clips connection endpoint as a fallback."""
+        try:
+            resp = context.doc_id_graphql_query(
+                "27234427476213202",
+                {"data": {"include_feed_video": True, "page_size": 12,
+                           "target_user_id": str(user_id)}},
+            )
+            edges = ((resp.get("data") or {})
+                     .get("xdt_api__v1__clips__user__connection_v2") or {})
+            for edge in edges.get("edges") or []:
+                media = (edge.get("node") or {}).get("media") or {}
+                if media.get("code") == shortcode:
+                    return media.get("play_count")
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
     def shortcode_to_mediaid(code: str) -> int:
         if len(code) > 11:
             raise InvalidArgumentException("Wrong shortcode \"{0}\", unable to convert to mediaid.".format(code))
@@ -360,6 +380,12 @@ class Post:
                 pic_json["video_view_count"] = media["view_count"]
             if media.get("play_count") is not None:
                 pic_json["video_play_count"] = media["play_count"]
+            if media_type == 2 and pic_json.get("video_view_count") is None:
+                play_count = Post._fetch_play_count_from_clips(
+                    self._context, media["user"]["pk"], media["code"]
+                )
+                if play_count is not None:
+                    pic_json["video_play_count"] = play_count
             caption = media.get("caption")
             caption_text = caption.get("text") if isinstance(caption, dict) else None
             pic_json["edge_media_to_caption"] = (
@@ -668,7 +694,10 @@ class Post:
 
         .. versionadded:: 4.2.6"""
         if self.is_video:
-            return self._field('video_view_count')
+            try:
+                return self._field('video_view_count')
+            except KeyError:
+                return None
         return None
 
     @property
@@ -677,7 +706,10 @@ class Post:
 
         .. versionadded:: 4.14.3"""
         if self.is_video:
-            return self._field('video_play_count')
+            try:
+                return self._field('video_play_count')
+            except KeyError:
+                return None
         return None
 
     @property

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -283,9 +283,10 @@ class Post:
         """Normalize a Polaris media item to a legacy-compatible node, preserving the source structure."""
         media_types = {1: "GraphImage", 2: "GraphVideo", 8: "GraphSidecar"}
         media_type = media.get("media_type")
-        if not isinstance(media_type, int) or not (
-            typename := media_types.get(media_type)
-        ):
+        typename = None
+        if isinstance(media_type, int):
+            typename = media_types.get(media_type)
+        if not typename:
             raise BadResponseException(f"Unknown media_type in metadata: {media_type}.")
         pic_json: Dict[str, Any] = media.copy()
         pic_json["shortcode"] = media["code"]

--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -283,8 +283,9 @@ class Post:
         """Normalize a Polaris media item to a legacy-compatible node, preserving the source structure."""
         media_types = {1: "GraphImage", 2: "GraphVideo", 8: "GraphSidecar"}
         media_type = media.get("media_type")
-        typename = media_types.get(media_type)
-        if not typename:
+        if not isinstance(media_type, int) or not (
+            typename := media_types.get(media_type)
+        ):
             raise BadResponseException(f"Unknown media_type in metadata: {media_type}.")
         pic_json: Dict[str, Any] = media.copy()
         pic_json["shortcode"] = media["code"]


### PR DESCRIPTION
Fixes #2704.

## Problem

Around June, 2026, Instagram deprecated the GraphQL `doc_id` with `8845758582119845` (`xdt_shortcode_media`), causing `_obtain_metadata()` to receive `null` for the `xdt_shortcode_media` field and crash with:

    TypeError: 'NoneType' object is not subscriptable

## Changes

**`instaloader/structures.py` — `_obtain_metadata()`**

Migrates to the new working endpoint:
- doc_id: `27128499623469141` (`PolarisPostRootQuery`)
- response field: `xdt_api__v1__media__shortcode__web_info.items[0]`

The new endpoint returns data in v1/iPhone API format (`media_type` integer, `code`, `pk`, `taken_at`, `image_versions2`, etc.) instead of the legacy GraphQL format. The method now converts this to the legacy field names that the rest of the codebase expects (`__typename`, `shortcode`, `id`, `taken_at_timestamp`, `display_url`, `edge_media_to_caption`, etc.).

**`instaloader/instaloadercontext.py` — `doc_id_graphql_query()`**

The new endpoint requires an `X-CSRFToken` request header (cookie alone is rejected with 403). The method now fetches a `csrftoken` from Instagram if the session doesn't have one yet (anonymous use), then passes it as the `x-csrftoken` header.

## Note for issue subscribers

Hope this solution helps you 🙏