### PR TITLE
fix: raise BadResponseException for None GraphQL responses in Post._obtain_metadata

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -319,9 +319,19 @@ class Post:
 
     def _obtain_metadata(self):
         if not self._full_metadata_dict:
-            pic_json = self._context.doc_id_graphql_query(
+            response = self._context.doc_id_graphql_query(
                 "8845758582119845", {"shortcode": self.shortcode}
-            )["data"]["xdt_shortcode_media"]
+            )
+            if response is None:
+                raise BadResponseException(
+                    "Fetching Post metadata failed: empty response from server."
+                )
+            response_data = response.get("data")
+            if response_data is None:
+                raise BadResponseException(
+                    "Fetching Post metadata failed: response contained no 'data' field."
+                )
+            pic_json = response_data.get("xdt_shortcode_media")
             if pic_json is None:
                 raise BadResponseException("Fetching Post metadata failed.")
             try:


### PR DESCRIPTION
Fixes #2704

## The bug

When fetching a Post's metadata via `doc_id_graphql_query`, the response can have `data: null`, a missing `xdt_shortcode_media` key, or no `data` field at all. The existing code did:

```python
pic_json = self._context.doc_id_graphql_query(... )["data"]["xdt_shortcode_media"]
```

If `data` is `None`, the chain `...["data"]["xdt_shortcode_media"]` raises a cryptic `TypeError: 'NoneType' object is not subscriptable`, which crashes instaloader instead of producing the clear `BadResponseException("Fetching Post metadata failed.")` that the rest of the code already uses for this exact scenario.

## The fix

Mirror the defensive pattern already used in `Profile._obtain_metadata` (line ~994): check each step before subscripting and raise a clear `BadResponseException` with a specific message.

```python
response = self._context.doc_id_graphql_query(...)
if response is None:
    raise BadResponseException("Fetching Post metadata failed: empty response from server.")
response_data = response.get("data")
if response_data is None:
    raise BadResponseException("Fetching Post metadata failed: response contained no 'data' field.")
pic_json = response_data.get("xdt_shortcode_media")
if pic_json is None:
    raise BadResponseException("Fetching Post metadata failed.")
```

The existing `if pic_json is None: raise BadResponseException(...)` check below the original chained subscript was unreachable because the `TypeError` would fire first.

## How I tested

I wrote a small harness that mocks the `_context.doc_id_graphql_query` return value and exercises the new code path on a real `Post` instance for five cases:

1. response is `None` → `BadResponseException` with "empty response from server."
2. response is `{"data": None}` → `BadResponseException` with "no 'data' field."
3. response is `{"data": {"xdt_shortcode_media": None}}` → `BadResponseException` with "Fetching Post metadata failed."
4. response is `{"data": {"xdt_shortcode_media": {...valid...}}}` → returns the validated `pic_json` (happy path preserved).
5. response is `{}` (no `data` key) → `BadResponseException` with "no 'data' field."

All five cases pass. The exact traceback from issue #2704 (`TypeError: 'NoneType' object is not subscriptable` at `structures.py:322`) is no longer reachable.

I also ran the existing test suite to confirm I did not regress the happy path. The single existing failure (`test_get_id_by_username`) is a pre-existing network test that hits real Instagram and was already failing on `master` before my change — unrelated to this fix.
