### PR TITLE
Fix caption mentions being missed after a newline

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -152,7 +152,7 @@ _hashtag_regex = re.compile(r"(?:#)((?:\w){1,150})")
 # support Unicode and a word/beginning of string delimiter at the beginning to ensure
 # that no email addresses join the list of mentions.
 # http://blog.jstassen.com/2016/03/code-regex-for-instagram-username-and-hashtags/
-_mention_regex = re.compile(r"(?:^|[^\w\n]|_)(?:@)(\w(?:(?:\w|(?:\.(?!\.))){0,28}(?:\w))?)", re.ASCII)
+_mention_regex = re.compile(r"(?:^|\W|_)(?:@)(\w(?:(?:\w|(?:\.(?!\.))){0,28}(?:\w))?)", re.ASCII)
 
 
 def _optional_normalize(string: Optional[str]) -> Optional[str]:

--- a/test/instaloader_unittests.py
+++ b/test/instaloader_unittests.py
@@ -210,5 +210,28 @@ class TestInstaloaderLoggedIn(TestInstaloaderAnonymously):
                 break
 
 
+class TestCaptionMentions(unittest.TestCase):
+    """Caption parsing, which requires no network access."""
+
+    @staticmethod
+    def _post_with_caption(caption: str) -> instaloader.Post:
+        return instaloader.Post(None, {"shortcode": "BhrEy4nBFVU", "caption": caption})
+
+    def test_caption_mentions(self):
+        for caption, expected in [
+                ("@alice at the beginning", ["alice"]),
+                ("preceded by a space @bob", ["bob"]),
+                ("preceded by a newline\n@carol", ["carol"]),
+                ("multiple lines\n@dave\n@erin", ["dave", "erin"]),
+                ("no mentions here", []),
+        ]:
+            with self.subTest(caption=caption):
+                self.assertEqual(self._post_with_caption(caption).caption_mentions, expected)
+
+    def test_caption_mentions_ignores_email_addresses(self):
+        post = self._post_with_caption("write to alice@example.com\ncontact @bob instead")
+        self.assertEqual(post.caption_mentions, ["bob"])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2709.

`_mention_regex` requires the character before `@` to be a non-word character, but the class it uses (`[^\w\n]`) also excludes `\n`. Since the pattern isn't compiled with `re.MULTILINE`, `^` only matches at the start of the whole caption, so a mention sitting at the start of any later line matches neither alternative and is dropped.

```python
>>> Post(None, {"caption": "check out\n@aandergr"}).caption_mentions
[]
```

This came in with 8784ac7, which moved the regexes to module level and changed the prefix from `\W` to `[^\w\n]`. `\W` already covers `\n`, so this restores it.

The prefix exists to keep email addresses out of the results, and that still works: the character before `@` in an address is a word character, so neither `^`, `\W`, nor `_` can match there. `alice@example.com` returns no mentions before and after this change.

Added a `TestCaptionMentions` case covering mentions at the start of the caption, after a space, after a newline, several on consecutive lines, and the email-address guard. It builds a `Post` from a caption dict directly, so it needs no network access or login, unlike the existing tests. It fails on the current regex and passes with this one.

`Profile.biography_mentions` and `StoryItem.caption_mentions` use the same regex, so they get the same fix.
