### PR TITLE
Fix from_username misreporting existing small accounts as nonexistent

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -912,6 +912,24 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
+        # Primary: web_profile_info answers a username lookup directly, in legacy node
+        # format. The search below misses many smaller accounts entirely, which would
+        # misreport an existing profile as nonexistent, so it is only the fallback.
+        if context.is_logged_in:
+            try:
+                metadata = context.get_iphone_json(
+                    'api/v1/users/web_profile_info/?username={0}'.format(username), params={})
+                user_data = metadata.get('data', {}).get('user')
+                if user_data is not None:
+                    return cls(context, user_data)
+                if metadata.get('status') == 'ok':
+                    # healthy answer, no such user — authoritative
+                    raise ProfileNotExistsException(
+                        "Profile {} does not exist.".format(username))
+            except (QueryReturnedBadRequestException, QueryReturnedNotFoundException,
+                    KeyError):
+                pass
+        # Fallback: resolve via search.
         data = context.doc_id_graphql_query("26347858941511777", {"hasQuery": True, "query": username})["data"]
         if data:
             for user in data["xdt_api__v1__fbsearch__non_profiled_serp"]["users"]:


### PR DESCRIPTION
## Problem

Since username resolution migrated to the fbsearch GraphQL endpoint (#2652), `Profile.from_username` resolves usernames exclusively through Instagram's search. Search omits many smaller accounts entirely, so an existing, public profile raises `ProfileNotExistsException` on every by-username lookup:

```
$ instaloader --login <user> <small_profile>
<small_profile>: Profile <small_profile> does not exist.
```

Profiles already recorded in `--latest-stamps` are unaffected (they resolve by stored profile id), which makes the failure look profile-specific: it bites exactly when downloading a profile for the first time.

Reproduced with a logged-in session against a public 7-post account: the fbsearch query returns an empty `users` list for its exact username, while `web_profile_info` returns the full user node for the same username in the same session.

## Fix

When logged in, query `web_profile_info` first: it answers a username lookup directly and returns the node in legacy format, so no extra normalization is needed. A healthy `status: ok` response with a null user is treated as authoritative nonexistence. Transient errors (400/404) fall through to the existing search-based lookup, which also remains the path for anonymous contexts.

## Testing

- `Profile.from_username` on a small public account that fbsearch does not return: previously `ProfileNotExistsException`, now resolves and downloads.
- Regular profiles, private profiles, and genuinely nonexistent usernames behave as before (nonexistent still raises `ProfileNotExistsException`).
- Anonymous usage unchanged.