### PR TITLE
Degrade gracefully when a single media's info endpoint answers feedback_required

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -354,9 +354,27 @@ class Post:
             raise IPhoneSupportDisabledException("iPhone support is disabled.")
         if not self._context.is_logged_in:
             raise LoginRequiredException("Login required to access iPhone media info endpoint.")
-        if not self._iphone_struct_:
-            data = self._context.get_iphone_json(path='api/v1/media/{}/info/'.format(self.mediaid), params={})
-            self._iphone_struct_ = data['items'][0]
+        if self._iphone_struct_ is None:
+            try:
+                data = self._context.get_iphone_json(
+                    path='api/v1/media/{}/info/'.format(self.mediaid), params={})
+                self._iphone_struct_ = data['items'][0]
+            except AbortDownloadException as err:
+                # Instagram answers feedback_required for the info endpoint of SOME
+                # media (e.g. reels with licensed audio or region locks) while the
+                # same call succeeds for neighboring media in the same run — a
+                # media-level refusal, not an account-level flag. This lookup only
+                # upgrades quality, so degrade to the standard version instead of
+                # aborting the whole download pass. Repeated hits across distinct
+                # media DO look account-level, so re-raise then.
+                aborts = getattr(self._context, '_media_info_aborts', 0) + 1
+                setattr(self._context, '_media_info_aborts', aborts)
+                if aborts >= 5:
+                    raise
+                self._context.error(
+                    "iPhone media info unavailable for {} ({}); continuing with "
+                    "standard quality.".format(self, err))
+                self._iphone_struct_ = {}
         return self._iphone_struct_
 
     def _field(self, *keys) -> Any:


### PR DESCRIPTION
## Problem

Instagram returns `400 Bad Request` with `feedback_required` for `api/v1/media/<id>/info/` on certain media (observed repeatedly with reels carrying licensed audio), while the same call succeeds for neighboring media in the same session moments later. Because `feedback_required` raises `AbortDownloadException` (which intentionally bypasses the per-post error catchers), one such media kills the entire download pass — and since it is deterministic for that media, every retry aborts on the same first item. The profile can never be downloaded past it:

```
[  1] [Wow — a snippet of our gig at…]
Download aborted: 400 Bad Request - "fail" status, message "feedback_required" when accessing https://i.instagram.com/api/v1/media/3711864895911901816/info/.
```

The account itself is fine: downloading a different profile immediately afterwards works.

## Fix

The media-info lookup in `Post._iphone_struct` only *upgrades* image/video quality — both call sites already degrade gracefully on other errors. Catch `AbortDownloadException` there, log a warning, and fall back to standard quality for that one media (cached, so it is not re-requested).

Account-level protection is preserved: if several distinct media (5) hit `feedback_required` in one run, the pattern does look like an account flag and the exception is re-raised as before.

## Testing

- A restricted reel that previously aborted the whole `--reels` pass now downloads in standard quality with a warning, and the pass continues through the rest of the backlog.
- Simulated repeated failures across 5 distinct media re-raise `AbortDownloadException`.
- Media where the info endpoint succeeds are unaffected.