### PR TITLE
Handle null stories reel responses

### DIFF
--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -808,7 +808,10 @@ class Instaloader:
                                               {"only_stories": True})["data"]["user"]
             if data is None:
                 raise BadResponseException('Bad stories reel JSON.')
-            userids = list(edge["node"]["id"] for edge in data["feed_reels_tray"]["edge_reels_tray_to_reel"]["edges"])
+            feed_reels_tray = data["feed_reels_tray"]
+            if feed_reels_tray is None:
+                return
+            userids = list(edge["node"]["id"] for edge in feed_reels_tray["edge_reels_tray_to_reel"]["edges"])
 
         def _userid_chunks():
             assert userids is not None

--- a/test/instaloader_unittests.py
+++ b/test/instaloader_unittests.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from itertools import islice
 from typing import Optional
+from unittest.mock import Mock
 
 import instaloader
 
@@ -24,6 +25,17 @@ EMPTY_PROFILE = "not_public"
 EMPTY_PROFILE_ID = 1928659031
 
 ratecontroller: Optional[instaloader.RateController] = None
+
+
+class TestInstaloaderStories(unittest.TestCase):
+
+    def test_null_feed_reels_tray(self):
+        loader = instaloader.Instaloader()
+        self.addCleanup(loader.close)
+        loader.context.username = "test"
+        loader.context.graphql_query = Mock(return_value={"data": {"user": {"feed_reels_tray": None}}})
+
+        self.assertEqual(list(loader.get_stories()), [])
 
 
 class TestInstaloaderAnonymously(unittest.TestCase):


### PR DESCRIPTION
Fixes #2720.

Treats a null `feed_reels_tray` response as an empty visible-stories result instead of indexing into `None`. The regression test reproduces the reported response without network access and fails before this fix.
