### PR TITLE
Document Firefox 147+ XDG path for troubleshooting

### DIFF
--- a/docs/codesnippets/615_import_firefox_session.py
+++ b/docs/codesnippets/615_import_firefox_session.py
@@ -14,8 +14,13 @@ def get_cookiefile():
     default_cookiefile = {
         "Windows": "~/AppData/Roaming/Mozilla/Firefox/Profiles/*/cookies.sqlite",
         "Darwin": "~/Library/Application Support/Firefox/Profiles/*/cookies.sqlite",
-    }.get(system(), "~/.mozilla/firefox/*/cookies.sqlite")
-    cookiefiles = glob(expanduser(default_cookiefile))
+    }.get(system(), None)
+    if default_cookiefile:
+        cookiefiles = glob(expanduser(default_cookiefile))
+    else:
+        # Check Firefox 147+ XDG path, then legacy
+        cookiefiles = glob(expanduser("~/.config/mozilla/firefox/*/cookies.sqlite")) or \
+                      glob(expanduser("~/.mozilla/firefox/*/cookies.sqlite"))
     if not cookiefiles:
         raise SystemExit("No Firefox cookies.sqlite file found. Use -c COOKIEFILE.")
     return cookiefiles[0]


### PR DESCRIPTION
# Problem
`get_cookiefile()` in docs/codesnippets/615_import_firefox_session.py only checks the legacy `~/.mozilla/firefox/` path on Linux. Firefox 147+ uses the XDG path, `~/.config/mozilla/firefox/`, for new profiles (https://bugzilla.mozilla.org/show_bug.cgi?id=259356). This breaks the `--load-cookies=firefox` flag that calls browser_cookie3 and fails at that hardcoded path: users (at least on Arch) on Firefox 147+ with fresh profiles get `browser_cookie3.BrowserCookieError: Could not find Firefox profile directory` even though a valid profile exists. Because it seems to be an unmaintained project and dependency here, this is just a troubleshooting doc update, and sadly not a proper fix

# Fix
In `docs/codesnippets/615_import_firefox_session.py`, the fix is very easy and done here. I just added the XDG path first when `get_cookiefile()` falls back to the (now legacy) linux path

Importing `615_import_firefox_session.py` with `importlib.util` and confirmed that calling `get_cookiefile()` prints the right path for XDG only, legacy only, and not installed cases.
That said, I would consider it ready to be merged. I'd really appreciate any feedback, as I'm a student hoping to get more involved in open source.