### PR TITLE
Send Instagram API requests over HTTP/2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,5 @@ pefile = "*"          # Needed for pyinstaller on Windows
 
 [packages]
 requests = "*"
+httpx = {extras = ["http2"], version = "*"}
 browser-cookie3 = "*"

--- a/instaloader/http2.py
+++ b/instaloader/http2.py
@@ -90,14 +90,18 @@ class HTTP2Adapter(requests.adapters.HTTPAdapter):
         # Instagram's API hosts, whose replies are small JSON documents. Media
         # files are downloaded from the CDN, which the adapter is not mounted on.
         body = response.content
-        headers = urllib3.HTTPHeaderDict()
-        for name, value in response.headers.multi_items():
-            if name.lower() not in _SKIPPED_RESPONSE_HEADERS:
-                headers.add(name, value)
-        headers['Content-Length'] = str(len(body))
+        # Passing the headers as a list of pairs rather than building a
+        # urllib3.HTTPHeaderDict keeps duplicate headers (Set-Cookie) intact
+        # while working on both urllib3 1.x and 2.x, which export the class
+        # from different places.
+        headers = [(name, value) for name, value in response.headers.multi_items()
+                   if name.lower() not in _SKIPPED_RESPONSE_HEADERS]
+        headers.append(('Content-Length', str(len(body))))
         return urllib3.HTTPResponse(
             body=io.BytesIO(body),
-            headers=headers,
+            # urllib3 accepts an iterable of pairs here, but is annotated for
+            # mappings only, which cannot carry a repeated Set-Cookie.
+            headers=headers,  # type: ignore[arg-type]
             status=response.status_code,
             reason=response.reason_phrase,
             version=20 if response.http_version == 'HTTP/2' else 11,

--- a/instaloader/http2.py
+++ b/instaloader/http2.py
@@ -1,0 +1,110 @@
+"""HTTP/2 transport for Instagram requests.
+
+Instagram has started answering HTTP/1.1 requests to its web API with ``429 Too
+Many Requests`` and an empty body. It is not a rate limit: it hits the very first
+request of a fresh session, and neither the session, the account nor the IP
+address makes a difference. The same request over HTTP/2 succeeds, so Instaloader
+has to speak HTTP/2 -- which Requests, being built on urllib3, cannot do.
+
+This module bridges the gap with a :class:`requests.adapters.HTTPAdapter` that
+hands the request over to HTTPX (which does speak HTTP/2) and converts the reply
+back into a :class:`requests.Response`. Mounting the adapter keeps cookie
+handling, redirects and the rest of Instaloader's Requests-based code untouched.
+"""
+
+import http.client
+import io
+from typing import Optional
+
+import httpx
+import requests
+import requests.adapters
+import urllib3
+
+# Set by the transport itself; forwarding them to HTTPX would conflict with the
+# HTTP/2 pseudo-headers or with the body HTTPX re-encodes.
+_SKIPPED_REQUEST_HEADERS = frozenset({'host', 'connection', 'transfer-encoding', 'content-length'})
+
+# HTTPX transparently decompresses the body, so passing these on would make
+# urllib3 attempt to decode the payload a second time.
+_SKIPPED_RESPONSE_HEADERS = frozenset({'content-encoding', 'content-length', 'transfer-encoding'})
+
+
+class _OriginalResponse:
+    """The bit of :mod:`http.client` API that Requests needs to extract cookies."""
+
+    def __init__(self, headers: httpx.Headers):
+        self.msg = http.client.HTTPMessage()
+        for name, value in headers.multi_items():
+            self.msg.add_header(name, value)
+
+    def isclosed(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+
+class HTTP2Adapter(requests.adapters.HTTPAdapter):
+    """Requests transport adapter that performs the request over HTTP/2.
+
+    .. versionadded:: 4.15.4"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._client = httpx.Client(http2=True, follow_redirects=False, timeout=None)
+
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+        headers = {name: value for name, value in request.headers.items()
+                   if name.lower() not in _SKIPPED_REQUEST_HEADERS}
+        try:
+            response = self._client.request(
+                request.method,
+                request.url,
+                headers=headers,
+                content=request.body,
+                timeout=self._httpx_timeout(timeout),
+            )
+        except httpx.TimeoutException as err:
+            raise requests.exceptions.Timeout(err, request=request) from err
+        except httpx.HTTPError as err:
+            raise requests.exceptions.ConnectionError(err, request=request) from err
+        return self.build_response(request, self._to_urllib3_response(response))
+
+    def close(self) -> None:
+        self._client.close()
+        super().close()
+
+    @staticmethod
+    def _httpx_timeout(timeout) -> Optional[httpx.Timeout]:
+        if timeout is None:
+            return None
+        if isinstance(timeout, tuple):
+            connect, read = timeout
+            return httpx.Timeout(read, connect=connect)
+        return httpx.Timeout(timeout)
+
+    @staticmethod
+    def _to_urllib3_response(response: httpx.Response) -> urllib3.HTTPResponse:
+        # Reading the body eagerly is fine here: the adapter only serves
+        # Instagram's API hosts, whose replies are small JSON documents. Media
+        # files are downloaded from the CDN, which the adapter is not mounted on.
+        body = response.content
+        headers = urllib3.HTTPHeaderDict()
+        for name, value in response.headers.multi_items():
+            if name.lower() not in _SKIPPED_RESPONSE_HEADERS:
+                headers.add(name, value)
+        headers['Content-Length'] = str(len(body))
+        return urllib3.HTTPResponse(
+            body=io.BytesIO(body),
+            headers=headers,
+            status=response.status_code,
+            reason=response.reason_phrase,
+            version=20 if response.http_version == 'HTTP/2' else 11,
+            preload_content=False,
+            decode_content=False,
+            # urllib3 only ever touches ._original_response.msg here, which the
+            # shim provides; it is not a real http.client.HTTPResponse.
+            original_response=_OriginalResponse(response.headers),  # type: ignore[arg-type]
+            request_method=response.request.method,
+        )

--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -17,11 +17,27 @@ import requests
 import requests.utils
 
 from .exceptions import *
+from .http2 import HTTP2Adapter
+
+# Instagram rejects HTTP/1.1 requests to these hosts with "429 Too Many Requests",
+# so they are served by the HTTP/2 adapter. Media files are downloaded from the
+# CDN, which is left on the default transport.
+INSTAGRAM_HOSTS = ('https://www.instagram.com/', 'https://i.instagram.com/')
+
+
+def new_session() -> requests.Session:
+    """Creates a :class:`requests.Session` that talks to Instagram over HTTP/2.
+
+    .. versionadded:: 4.15.4"""
+    session = requests.Session()
+    for host in INSTAGRAM_HOSTS:
+        session.mount(host, HTTP2Adapter())
+    return session
 
 
 def copy_session(session: requests.Session, request_timeout: Optional[float] = None) -> requests.Session:
     """Duplicates a requests.Session."""
-    new = requests.Session()
+    new = new_session()
     new.cookies = requests.utils.cookiejar_from_dict(requests.utils.dict_from_cookiejar(session.cookies))
     new.headers = session.headers.copy()  # type: ignore
     # Override default timeout behavior.
@@ -202,7 +218,7 @@ class InstaloaderContext:
 
     def get_anonymous_session(self) -> requests.Session:
         """Returns our default anonymous requests.Session object."""
-        session = requests.Session()
+        session = new_session()
         session.cookies.update({'sessionid': '', 'mid': '', 'ig_pr': '1',
                                 'ig_vw': '1920', 'csrftoken': '',
                                 's_network': '', 'ds_user_id': ''})
@@ -222,7 +238,7 @@ class InstaloaderContext:
 
     def load_session(self, username, sessiondata):
         """Not meant to be used directly, use :meth:`Instaloader.load_session`."""
-        session = requests.Session()
+        session = new_session()
         session.cookies = requests.utils.cookiejar_from_dict(sessiondata)
         session.headers.update(self._default_http_header())
         session.headers.update({'X-CSRFToken': session.cookies.get_dict()['csrftoken']})
@@ -266,7 +282,7 @@ class InstaloaderContext:
         import http.client
         # pylint:disable=protected-access
         http.client._MAXHEADERS = 200
-        session = requests.Session()
+        session = new_session()
         session.cookies.update({'sessionid': '', 'mid': '', 'ig_pr': '1',
                                 'ig_vw': '1920', 'ig_cb': '1', 'csrftoken': '',
                                 's_network': '', 'ds_user_id': ''})

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_version():
 if sys.version_info < (3, 9):
     sys.exit('Instaloader requires Python >= 3.9.')
 
-requirements = ['requests>=2.25']
+requirements = ['requests>=2.25', 'httpx[http2]>=0.27']
 optional_requirements = {
     'browser_cookie3': ['browser_cookie3>=0.19.1'],
 }

--- a/test/instaloader_unittests.py
+++ b/test/instaloader_unittests.py
@@ -8,6 +8,8 @@ from itertools import islice
 from typing import Optional
 
 import instaloader
+from instaloader.http2 import HTTP2Adapter
+from instaloader.instaloadercontext import default_user_agent, new_session
 
 PROFILE_WITH_HIGHLIGHTS = 325732271
 PUBLIC_PROFILE = "selenagomez"
@@ -231,6 +233,29 @@ class TestCaptionMentions(unittest.TestCase):
     def test_caption_mentions_ignores_email_addresses(self):
         post = self._post_with_caption("write to alice@example.com\ncontact @bob instead")
         self.assertEqual(post.caption_mentions, ["bob"])
+
+
+class TestHTTP2Transport(unittest.TestCase):
+    """Instagram answers HTTP/1.1 requests to its API with 429, so they must go over HTTP/2."""
+
+    def test_adapter_is_mounted_for_instagram_only(self):
+        session = new_session()
+        self.addCleanup(session.close)
+        for url in ("https://www.instagram.com/", "https://i.instagram.com/api/v1/"):
+            with self.subTest(url=url):
+                self.assertIsInstance(session.get_adapter(url), HTTP2Adapter)
+        # Media is downloaded from the CDN, which stays on the default transport.
+        self.assertNotIsInstance(session.get_adapter("https://scontent.cdninstagram.com/"), HTTP2Adapter)
+
+    def test_web_profile_info_is_not_rate_limited(self):
+        session = new_session()
+        self.addCleanup(session.close)
+        session.headers.update({'User-Agent': default_user_agent(),
+                                'x-ig-app-id': '936619743392459'})
+        resp = session.get("https://www.instagram.com/api/v1/users/web_profile_info/",
+                           params={'username': PUBLIC_PROFILE})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["data"]["user"]["username"], PUBLIC_PROFILE)
 
 
 if __name__ == '__main__':

--- a/test/instaloader_unittests.py
+++ b/test/instaloader_unittests.py
@@ -7,6 +7,9 @@ import unittest
 from itertools import islice
 from typing import Optional
 
+import httpx
+import requests
+
 import instaloader
 from instaloader.http2 import HTTP2Adapter
 from instaloader.instaloadercontext import default_user_agent, new_session
@@ -246,6 +249,35 @@ class TestHTTP2Transport(unittest.TestCase):
                 self.assertIsInstance(session.get_adapter(url), HTTP2Adapter)
         # Media is downloaded from the CDN, which stays on the default transport.
         self.assertNotIsInstance(session.get_adapter("https://scontent.cdninstagram.com/"), HTTP2Adapter)
+
+    def test_response_is_converted_for_requests(self):
+        """The httpx reply must survive the trip into Requests, on urllib3 1.x as well as 2.x."""
+        class _FakeClient:
+            @staticmethod
+            def request(method, url, headers=None, content=None, timeout=None):
+                return httpx.Response(
+                    200,
+                    headers=[('Content-Type', 'application/json'),
+                             ('Set-Cookie', 'csrftoken=abc; Path=/'),
+                             ('Set-Cookie', 'sessionid=xyz; Path=/')],
+                    content=b'{"status": "ok"}',
+                    request=httpx.Request(method, str(url), headers=headers),
+                    extensions={'http_version': b'HTTP/2'})
+
+            @staticmethod
+            def close():
+                pass
+
+        adapter = HTTP2Adapter()
+        adapter._client = _FakeClient()  # pylint: disable=protected-access
+        session = requests.Session()
+        self.addCleanup(session.close)
+        session.mount("https://www.instagram.com/", adapter)
+        resp = session.get("https://www.instagram.com/api/v1/users/web_profile_info/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "ok"})
+        # Both Set-Cookie headers must make it into the jar, not just the last one.
+        self.assertEqual(session.cookies.get_dict(), {"csrftoken": "abc", "sessionid": "xyz"})
 
     def test_web_profile_info_is_not_rate_limited(self):
         session = new_session()


### PR DESCRIPTION
# Send Instagram API requests over HTTP/2

Fixes #2726.

## The cause

Instagram has started answering HTTP/1.1 requests to its web API with `429 Too
Many Requests` and an empty body. The identical request over HTTP/2 succeeds.
This is not a rate limit: it triggers on the very first request of a fresh
session, and is independent of account, session and IP address.

The rollout appears to be partial — many users are evidently still unaffected,
which is presumably why there is only one report of it so far — so this may not
reproduce everywhere yet. Both machines I tested from are in the same country,
so I cannot say how it behaves in other regions.

Reproduced on two unrelated networks and machines, with the same client, same
headers, same second:

```console
$ curl -s -o /dev/null -w '%{http_code} http/%{http_version}\n' --http2 \
    -H 'X-IG-App-ID: 936619743392459' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36' \
    'https://www.instagram.com/api/v1/users/web_profile_info/?username=instagram'
200 http/2

$ curl -s -o /dev/null -w '%{http_code} http/%{http_version}\n' --http1.1 \
    -H 'X-IG-App-ID: 936619743392459' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36' \
    'https://www.instagram.com/api/v1/users/web_profile_info/?username=instagram'
429 http/1.1
```

The TLS fingerprint is not the discriminator: HTTPX with its stock (non-browser)
fingerprint gets `200` over HTTP/2 and `429` over HTTP/1.1. Only the protocol
version matters.

Requests is built on urllib3, which speaks HTTP/1.1 only, so on an affected
network Instaloader cannot reach the API at all — which is what #2726 reports.
Browsers, whose behavior Instaloader mimics, do not use HTTP/1.1 here.

## The fix

A `requests.adapters.HTTPAdapter` subclass (`instaloader/http2.py`) that performs
the request with HTTPX and converts the reply back into a `requests.Response`.
It is mounted on `www.instagram.com` and `i.instagram.com` only.

This keeps the change small and leaves Instaloader's Requests-based code
untouched — cookie handling, redirects, rate controlling, session save/load and
the login flow all work exactly as before. Media downloads go to the CDN, which
is not affected by the 429 and stays on the default transport, so the streaming
download path is unchanged.

## Testing

Two tests are added in `TestHTTP2Transport`: one asserts the adapter is mounted
for the Instagram hosts but not for the CDN, the other is a direct regression
test for #2726 (`web_profile_info` must return `200`).

Verified manually against Instagram:

- anonymous `Profile.from_username()` on a public profile — the exact call from
  the issue
- logged-in access to a private profile, including GraphQL paging over posts
- media + metadata download of a post (CDN path)
- `save_session_to_file()`, which harvests `csrftoken` from `Set-Cookie` and so
  exercises the adapter's cookie conversion

`pylint instaloader` reports 10.00/10 and `mypy -m instaloader` is clean.

## Completeness

I consider this ready to be merged rather than a proof of concept, but two
decisions are yours:

- It adds `httpx[http2]` as a **required** dependency, since on an affected
  network the library cannot function without it. If you would rather not take
  one on, the adapter can be made optional, falling back to Requests when HTTPX
  is absent — happy to rework it.
- It is based on `master`, treating this as a bug fix. If you consider swapping
  the transport extensive enough to warrant an `upcoming/v4.X` cycle, I will
  gladly rebase.

No documentation change seemed necessary, as the transport is invisible to
users, but I am glad to add a note to the troubleshooting page.

---

Disclosure: this change was written with the help of Claude (Anthropic), which
is also recorded as a `Co-Authored-By` trailer on the commit. I have reviewed
and tested it myself.
