### PR TITLE
Make --count apply to profile downloads (posts and reels)

### DIFF
--- a/instaloader/__main__.py
+++ b/instaloader/__main__.py
@@ -309,6 +309,7 @@ def _main(instaloader: Instaloader, targetlist: List[str],
             storyitem_filter,
             latest_stamps=latest_stamps,
             reels=download_reels,
+            max_count=max_count,
         )
         if anonymous_retry_profiles:
             instaloader.context.log("Downloading anonymously: {}"
@@ -323,7 +324,8 @@ def _main(instaloader: Instaloader, targetlist: List[str],
                     fast_update=fast_update,
                     post_filter=post_filter,
                     latest_stamps=latest_stamps,
-                    reels=download_reels
+                    reels=download_reels,
+                    max_count=max_count
                 )
     except KeyboardInterrupt:
         print("\nInterrupted by user.", file=sys.stderr)
@@ -450,7 +452,8 @@ def main():
 
     g_cond.add_argument('-c', '--count',
                         help='Do not attempt to download more than COUNT posts. '
-                             'Applies to #hashtag, %%location_id, :feed, and :saved.')
+                             'Applies to profiles (posts and reels), #hashtag, '
+                             '%%location_id, :feed, and :saved.')
 
     g_login = parser.add_argument_group('Login (Download Private Profiles)',
                                         'Instaloader can login to Instagram. This allows downloading private profiles. '

--- a/instaloader/instaloader.py
+++ b/instaloader/instaloader.py
@@ -1285,10 +1285,14 @@ class Instaloader:
 
     def download_reels(self, profile: Profile, fast_update: bool = False,
                       post_filter: Optional[Callable[[Post], bool]] = None,
-                      latest_stamps: Optional[LatestStamps] = None) -> None:
+                      latest_stamps: Optional[LatestStamps] = None,
+                      max_count: Optional[int] = None) -> None:
         """Download reels videos of a profile.
 
         .. versionadded:: 4.14.0
+
+        .. versionchanged:: 4.15.4
+           Add `max_count` parameter.
 
         """
         self.context.log("Retrieving reels videos for profile {}.".format(profile.username))
@@ -1305,6 +1309,7 @@ class Instaloader:
             owner_profile=profile,
             takewhile=posts_takewhile,
             possibly_pinned=3,
+            max_count=max_count,
         )
         if latest_stamps is not None and reels.first_item is not None:
             latest_stamps.set_last_reels_timestamp(profile.username, reels.first_item.date_local)
@@ -1520,7 +1525,7 @@ class Instaloader:
                 if reels:
                     with self.context.error_catcher('Download reels of {}'.format(profile_name)):
                         self.download_reels(profile, fast_update=fast_update, post_filter=post_filter,
-                                           latest_stamps=latest_stamps)
+                                           latest_stamps=latest_stamps, max_count=max_count)
 
                 # Download IGTV, if requested
                 if igtv:


### PR DESCRIPTION
## Problem

`download_profiles()` accepts `max_count` and honors it for the posts loop, but `__main__` never forwards `--count` to it — so `instaloader --count 100 <profile>` silently downloads the full history. Reels have no cap at all (`download_reels()` lacks the parameter).

## Changes

- Forward `--count` from the CLI to `download_profiles()` (both the logged-in and anonymous-retry paths)
- Add `max_count` to `download_reels()` and pass it through to `posts_download_loop` (which already implements the limit)
- Update the `--count` help text to mention profiles

## Motivation

A gentle first clone of a large account: fetch the most recent N posts now instead of the entire history in one burst (the kind of burst most likely to trip Instagram's automation heuristics), and backfill later. With `--latest-stamps`, the stamp records the newest post either way, so subsequent runs stay incremental.

## Testing

- `--count 3` against a profile with thousands of posts downloads exactly 3 and stops (verified live)
- Without `--count`, behavior is unchanged
- `--count` with `--reels` caps the reels pass the same way