### PR TITLE
Do not lose a download when the filename cannot be printed

### DIFF
--- a/instaloader/instaloadercontext.py
+++ b/instaloader/instaloadercontext.py
@@ -675,7 +675,12 @@ class InstaloaderContext:
         """Write raw response data into a file.
 
         .. versionadded:: 4.2.1"""
-        self.log(filename, end=' ', flush=True)
+        try:
+            self.log(filename, end=' ', flush=True)
+        except UnicodeEncodeError:
+            # Console cannot represent the name; the download must not be lost over it.
+            self.log(filename.encode('ascii', errors='replace').decode('ascii'),
+                     end=' ', flush=True)
         with open(filename + '.temp', 'wb') as file:
             if isinstance(resp, requests.Response):
                 shutil.copyfileobj(resp.raw, file)

--- a/test/instaloader_unittests.py
+++ b/test/instaloader_unittests.py
@@ -1,7 +1,9 @@
 """Unit Tests for Instaloader"""
 
+import io
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from itertools import islice
@@ -231,6 +233,53 @@ class TestCaptionMentions(unittest.TestCase):
     def test_caption_mentions_ignores_email_addresses(self):
         post = self._post_with_caption("write to alice@example.com\ncontact @bob instead")
         self.assertEqual(post.caption_mentions, ["bob"])
+
+
+
+class TestWriteRawLogging(unittest.TestCase):
+    """write_raw logs the filename before writing it (#2553).
+
+    On Windows, sanitize_path rewrites ':' to U+FF1A, so --tagged produces a
+    name the console codepage cannot encode. The log call raised before the
+    write, losing the download.
+    """
+
+    def _write_raw_to(self, filename, encoding):
+        context = instaloader.InstaloaderContext(quiet=False)
+        console = io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors='strict')
+        stdout, sys.stdout = sys.stdout, console
+        try:
+            context.write_raw(b'payload', filename)
+        finally:
+            sys.stdout = stdout
+
+    def test_unprintable_filename_still_downloads(self):
+        directory = tempfile.mkdtemp()
+        try:
+            # The name instaloader itself builds for --tagged on Windows.
+            name = instaloader.instaloader._PostPathFormatter.sanitize_path(
+                ':tagged', force_windows_path=True)
+            self.assertIn('：', name)
+            target = os.path.join(directory, name + '.json')
+
+            self._write_raw_to(target, 'cp1252')
+
+            self.assertTrue(os.path.exists(target))
+            with open(target, 'rb') as file:
+                self.assertEqual(file.read(), b'payload')
+            self.assertFalse(os.path.exists(target + '.temp'))
+        finally:
+            shutil.rmtree(directory)
+
+    def test_printable_filename_is_unaffected(self):
+        directory = tempfile.mkdtemp()
+        try:
+            target = os.path.join(directory, 'plain.json')
+            self._write_raw_to(target, 'cp1252')
+            with open(target, 'rb') as file:
+                self.assertEqual(file.read(), b'payload')
+        finally:
+            shutil.rmtree(directory)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #2553.

`write_raw()` logs the filename *before* writing it, so when the console codepage cannot encode the name, `log()` raises and the file is never created. The reported symptom is a traceback, but the real cost is the lost download.

The unprintable character is one instaloader produces itself: `sanitize_path` rewrites `:` to U+FF1A on Windows, and `--tagged` passes `':tagged'`.

Guarded the same way as the three existing `log()` calls in `instaloader.py:461/475/479` rather than reconfiguring stdout globally, which would make those guards redundant and is a bigger decision than this bug warrants.

Verified on Windows with a cp1252 console: before, `write_raw` raises and the target file does not exist; after, it writes and no `.temp` is left behind. Two tests added, one for the unprintable name and one ASCII control that passes either way. pylint 10.00/10, mypy clean.
