### PR TITLE
Fix incorrect logged-in profile resolution for collaborative posts

### DIFF
--- a/instaloader/structures.py
+++ b/instaloader/structures.py
@@ -999,6 +999,27 @@ class Profile:
         :param username: Username
         :raises: :class:`ProfileNotExistsException`
         """
+        # Avoid web_profile_info rate limits for logged-in sessions.
+        if context.is_logged_in:
+            try:
+                response = context.doc_id_graphql_query(
+                    '7898261790222653',
+                    {
+                        "data": {"count": 12},
+                        "username": username,
+                        "__relay_internal__pv__PolarisFeedShareMenurelayprovider": False,
+                    },
+                )
+                edges = response["data"]["xdt_api__v1__feed__user_timeline_graphql_connection"]["edges"]
+                for edge in edges:
+                    user = edge.get("node", {}).get("user")
+                    if user and user.get("username", "").casefold() == username.casefold():
+                        profile = cls(context, user)
+                        profile._obtain_metadata()
+                        return profile
+            except (InstaloaderException, KeyError, TypeError):
+                pass
+
         # Resolve the profile through the web_profile_info endpoint, which works both
         # anonymously and when logged in and returns the complete profile node
         # (including the first page of posts). The GraphQL fbsearch query previously
@@ -1009,8 +1030,9 @@ class Profile:
             ).get("data")
         except QueryReturnedNotFoundException:
             data = None
-        if data and data.get("user"):
-            profile = cls(context, data["user"])
+        user = data.get("user") if data else None
+        if user and user.get("username", "").casefold() == username.casefold():
+            profile = cls(context, user)
             profile._has_full_metadata = True
             return profile
 


### PR DESCRIPTION
## Summary

`Profile.from_username()` may resolve the wrong account when using the
logged-in timeline GraphQL response.

Timeline results can contain collaborative posts where `node.user`
belongs to another account. Selecting the first returned user can
therefore make Instaloader silently download a different profile than
the one requested.

This change:

- uses the timeline GraphQL query for logged-in profile resolution;
- searches the returned edges for a case-insensitive exact username
  match instead of accepting the first user;
- never accepts a profile whose username differs from the requested
  username;
- keeps `web_profile_info` as a fallback when GraphQL cannot resolve
  the requested account.

Using GraphQL first also avoids the immediate HTTP 429 responses that
`web_profile_info` may return for logged-in sessions.

This is a follow-up to #2701. It is separate from the profile metadata
query flags fixed in #2696.